### PR TITLE
(DOCSP-10116): Add callout to online archive on mongodump/export

### DIFF
--- a/source/includes/fact-online-archive-callout.rst
+++ b/source/includes/fact-online-archive-callout.rst
@@ -1,0 +1,5 @@
+If you are archiving stale data to save on storage costs, consider
+:atlas:`Online Archive </online-archive/manage-online-archive>` in
+`MongoDB Atlas <https://www.mongodb.com/cloud?jmp=docs>`__. Online
+Archive automatically archives infrequently accessed data to
+fully-managed S3 buckets for cost-effective data tiering.

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -34,6 +34,10 @@ deployments.
    :binary:`~bin.mongorestore` which provides the corresponding
    binary data import capability.
 
+.. note::
+
+   .. include:: /includes/fact-online-archive-callout.rst
+
 Versioning
 ~~~~~~~~~~
 
@@ -972,5 +976,3 @@ As an alternative, users can use :binary:`~bin.mongodump` and
 <mongorestore --nsFrom>`).
 
 .. include:: /includes/extracts/clone-copy-db-same-instance.rst
-
-

--- a/source/mongoexport.txt
+++ b/source/mongoexport.txt
@@ -31,6 +31,10 @@ or CSV export of data stored in a MongoDB instance.
    :binary:`~bin.mongoimport` which provides the corresponding
    structured data import capability.
 
+.. note::
+
+   .. include:: /includes/fact-online-archive-callout.rst
+
 Versioning
 ~~~~~~~~~~
 


### PR DESCRIPTION
Heads up for review: Online Archive docs are being published later today. In the meantime, the link to those docs will not work.

Staged:

[mongodump](https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/jeffreyallen/DOCSP-10116/mongodump.html)

[mongoexport](https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/jeffreyallen/DOCSP-10116/mongoexport.html)