### PR TITLE
removes EOL notice re RHEL 7 and adds checkmark in to indicate support on s390x

### DIFF
--- a/source/includes/fact-platform-support.rst
+++ b/source/includes/fact-platform-support.rst
@@ -1,17 +1,5 @@
 .. |checkmark| unicode:: U+2713
 
-.. note:: Platform Support EOL Notice
-
-   .. list-table::
-      :widths: 25 75
-      :class: border-table
-
-      * - s390x ('zseries') 
-        - Support removed in MongoDB Database Tools ``104.0.0``.
-          Previous versions of the Database Tools that support the s390x
-          architecture can be downloaded from `Archived Releases
-          <https://www.mongodb.com/download-center/database-tools/releases/archive>`__.
-
 .. list-table::
   :header-rows: 1
   :class: compatibility
@@ -63,7 +51,7 @@
     - |checkmark|
     -
     - |checkmark|
-    -
+    - |checkmark|
 
   * - :abbr:`RHEL (Red Hat Enterprise Linux)` / CentOS 6
     - |checkmark|


### PR DESCRIPTION
## JIRA

https://jira.mongodb.org/browse/DOCS-14861

This issue:

- re-adds the checkbox back in for RHEL 7 s390x on the platform support table
- removes the note about s390x being EOL'd

## STAGING

[Platform Support table](https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/docsworker-xlarge/DOCS-14861-Remove-Platform-Support-EOL-Notice-for-zSeries/installation/installation/#platform-support)

