### PR TITLE
DOCSP-24503): Add MDB 6.0 to list of supported versions

### DIFF
--- a/source/includes/extracts-compatibility.yaml
+++ b/source/includes/extracts-compatibility.yaml
@@ -8,7 +8,6 @@ content: |
    - MongoDB 5.0
    - MongoDB 4.4
    - MongoDB 4.2
-   - MongoDB 4.0
 
    While the tools may work on earlier versions of MongoDB server, any
    such compatibility is not guaranteed.
@@ -24,7 +23,6 @@ content: |
    - MongoDB 5.0
    - MongoDB 4.4
    - MongoDB 4.2
-   - MongoDB 4.0
 
    While |tool-binary| may work on earlier versions of MongoDB server,
    any such compatibility is not guaranteed.

--- a/source/includes/extracts-compatibility.yaml
+++ b/source/includes/extracts-compatibility.yaml
@@ -4,6 +4,7 @@ content: |
    {+dbtools+} version ``{+release+}`` supports the following versions
    of the MongoDB server:
 
+   - MongoDB 6.0
    - MongoDB 5.0
    - MongoDB 4.4
    - MongoDB 4.2
@@ -19,6 +20,7 @@ content: |
    |tool-binary| version ``{+release+}`` supports the following versions
    of the MongoDB Server:
 
+   - MongoDB 6.0
    - MongoDB 5.0
    - MongoDB 4.4
    - MongoDB 4.2


### PR DESCRIPTION
Description: Update the version compatibility list to add MDB 6.0 and remove MDB 4.0.

JIRA: https://jira.mongodb.org/browse/DOCSP-24503

Staged: [mongodump - Compatibility](https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/docsworker-xlarge/DOCSP-24503/mongodump/#compatibility) (All other tool pages are also affected by this change. I'm just including one example link.)