### PR TITLE
DCOSP-29004 outdate version info

### DIFF
--- a/source/includes/fact-platform-support.rst
+++ b/source/includes/fact-platform-support.rst
@@ -89,12 +89,6 @@
     - |checkmark|
     -
 
-  * - Ubuntu 14.04
-    - |checkmark|
-    -
-    -
-    -
-
   * - Windows 8 and later
     - |checkmark|
     -

--- a/source/installation/installation-linux.txt
+++ b/source/installation/installation-linux.txt
@@ -40,7 +40,7 @@ platforms on the ``x86_64`` architecture:
 - Debian 10, 9, and 8
 - RHEL / CentOS 8, 7, and 6
 - SUSE 12
-- Ubuntu 20.04, 18.04, 16.04, and 14.04
+- Ubuntu 20.04, 18.04, 16.04
 
 In addition, the {+dbtools-short+} also support select Linux platforms
 on the ``arm64``, ``ppc64le``, and ``s390x`` architectures.  See

--- a/source/installation/installation-linux.txt
+++ b/source/installation/installation-linux.txt
@@ -40,7 +40,7 @@ platforms on the ``x86_64`` architecture:
 - Debian 10, 9, and 8
 - RHEL / CentOS 8, 7, and 6
 - SUSE 12
-- Ubuntu 20.04, 18.04, 16.04
+- Ubuntu 20.04, 18.04, and 16.04
 
 In addition, the {+dbtools-short+} also support select Linux platforms
 on the ``arm64``, ``ppc64le``, and ``s390x`` architectures.  See


### PR DESCRIPTION
STAGING
[Installation](https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/docsworker-xlarge/DOCSP-29004-outdated-version-info/installation/installation)
[Installation-linux](https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/docsworker-xlarge/DOCSP-29004-outdated-version-info/installation/installation-linux/#platform-support
)


[JIRA](https://jira.mongodb.org/browse/DOCSP-29004)
[DB Tools] Outdated information on the Database Tools installation page


[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=644aa7177efd2382b306dcc2) - unrelated build errors


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)