### PR TITLE
DOCSP-31005 DBTools 404s

### DIFF
--- a/source/mongoexport.txt
+++ b/source/mongoexport.txt
@@ -567,7 +567,7 @@ Options
    
       Starting in version ``100.1.0``, :program:`mongoexport` adds support
       for the ``MONGODB-AWS`` authentication mechanism when connecting
-      to a :atlas:`MongoDB Atlas <?tck=docs_server>`` cluster.
+      to a :atlas:`MongoDB Atlas <?tck=docs_server>` cluster.
 
    .. include:: /includes/list-table-auth-mechanisms.rst
    


### PR DESCRIPTION
## DESCRIPTION
Resolves 404'ing hyperlink in [mongoexport](https://www.mongodb.com/docs/atlasMongoDB%20Atlas%20%3C/?tck=docs_server%3E`) page.

## STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/docsworker-xlarge/DOCSP-31005-dbtools-404s/mongoexport/#examples:~:text=when%20connecting%20to%20a-,MongoDB%20Atlas,-cluster.

## JIRA
https://jira.mongodb.org/browse/DOCSP-31005

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=649b52d2423952aeb905efae

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)