### PR TITLE
DOCS-9602: Update --oplog note

### DIFF
--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -839,6 +839,7 @@ Options
    
       - :option:`--db`
       - :option:`--collection`
+      - :option:`--dumpDbUsersAndRoles`
    
    .. seealso:: 
    


### PR DESCRIPTION
## DESCRIPTION
Update [`--oplog` note](https://www.mongodb.com/docs/database-tools/mongodump/#std-option-mongodump.--oplog) to include `--dumpDbUsersAndRoles` as an invalid option.

## STAGING
[mongodump](https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/docsworker-xlarge/docs-9602/mongodump/#std-option-mongodump.--oplog)

## JIRA
[DOCS-9602](https://jira.mongodb.org/browse/DOCS-9602)

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64ae994c423952aeb97cfcfd

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)