### PR TITLE
DOCSP-4849: indexes are built before data restored

### DIFF
--- a/source/mongorestore.txt
+++ b/source/mongorestore.txt
@@ -163,7 +163,7 @@ Rebuild Indexes
 ~~~~~~~~~~~~~~~
 
 :binary:`~bin.mongorestore` recreates indexes recorded by
-:binary:`~bin.mongodump`.
+:binary:`~bin.mongodump` before restoring data.
 
 .. note::
 


### PR DESCRIPTION
## DESCRIPTION
specify that indexes are built before data is restored by `mongorestore`

## STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/docsworker-xlarge/DOCSP-4849-indexes-before-import/mongorestore/#rebuild-indexes

## JIRA
https://jira.mongodb.org/browse/DOCSP-4849

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64aeed5a423952aeb9a6e4d9

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)