### PR TITLE
DOCS-16217 Add Authsource Behavior to MongoDump Page

### DIFF
--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -269,8 +269,9 @@ Using ``mongodump`` Without an ``authSource``
 
 When :urioption:`authSource` is not specified in the MongoDB URI, the 
 database name specified in :option:`--db` is used to authenticate your 
-``mongodump`` session and indicate the database being dumped. For a 
-detailed example see :ref:`mongodump-auth-dump`. 
+``mongodump`` session and indicate the database being dumped. For an 
+example of using a different database for authentication when using 
+``mongodump``, see :ref:`mongodump-auth-dump`. 
 
 Restore to Matching Server Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1113,7 +1114,7 @@ Authenticating to a Specific Database With ``mongodump``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To authenticate to a different database than the one being dumped, you 
-must specify the ``authSource`` option.
+must specify ``authSource`` in the MongoDB URI.
 
 In this example, the ``admin` database is being used for authentication,
 and ``testdb`` is being dumped.

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -1121,7 +1121,7 @@ In this example:
 - The username ``myuser`` and password ``mypassword`` is used. This user
   has read access to ``testdb``.
 - The ``admin`` database is used to authenticate the user.
-- The ``testdb`` is being dumped.
+- The ``testdb`` database is being dumped.
 
 .. code-block:: none
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -269,7 +269,7 @@ Using ``mongodump`` Without a ``authSource``
 
 When :urioption:`authSource` is not specified in the MongoDB URI, the database name provided 
 with the ``--db`` or ``-d`` flag is used to authenticate your ``mongodump`` session
-and *not* indicate the database being dumped.
+and **not** indicate the database being dumped.
 
 Restore to Matching Server Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -1121,7 +1121,7 @@ In this example:
 - The username ``myuser`` and password ``mypassword`` is used. This user
   has read access to ``testdb``.
 - The ``admin`` database is used to authenticate the user.
-- The ``testdb`` database is being dumped. 
+- The ``testdb`` database is being dumped.
 
 .. code-block:: none
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -268,7 +268,7 @@ Using ``mongodump`` Without an ``authSource``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When :urioption:`authSource` is not specified in the MongoDB URI, the database name provided 
-with the ``--db`` or ``-d`` flag is used to authenticate your ``mongodump`` session
+with :option:`--db` is used to authenticate your ``mongodump`` session
 and **not** indicate the database being dumped.
 
 Restore to Matching Server Version

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -264,6 +264,13 @@ Behavior
    the :dbtools:`--archive </mongodump/#std-option-mongodump.--archive>` 
    option.  
 
+Using ``mongodump`` Without a ``authSource``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When :urioption:`authSource` is not specified in the MongoDB URI, the database name provided 
+with the ``--db`` or ``-d`` flag is used to authenticate your ``mongodump`` session
+and *not* indicate the database being dumped.
+
 Restore to Matching Server Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -268,10 +268,10 @@ Using ``mongodump`` Without an ``authSource``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When :urioption:`authSource` is not specified in the MongoDB URI, the 
-database name specified in :option:`--db` is used to authenticate your 
-``mongodump`` session and indicate the database being dumped. For an 
-example of using a different database for authentication when using 
-``mongodump``, see :ref:`mongodump-auth-dump`. 
+database name specified in :option:`--db` is used both to authenticate 
+your ``mongodump`` session and to indicate the database being dumped. For 
+an example of using a different database for authentication when using 
+``mongodump``, see :ref:`mongodump-auth-dump`.
 
 Restore to Matching Server Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1110,10 +1110,10 @@ connect to a MongoDB Atlas cluster:
 
 .. _mongodump-auth-dump:
 
-Authenticating with a Specific Database With ``mongodump``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Authenticating with a Specific Database
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To authenticate to a different database than the one being dumped, you 
+To authenticate with a different database than the one being dumped, you 
 must specify ``authSource`` in the MongoDB URI.
 
 In this example:

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -264,8 +264,8 @@ Behavior
    the :dbtools:`--archive </mongodump/#std-option-mongodump.--archive>` 
    option.  
 
-Using ``mongodump`` Without a ``authSource``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using ``mongodump`` Without an ``authSource``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When :urioption:`authSource` is not specified in the MongoDB URI, the database name provided 
 with the ``--db`` or ``-d`` flag is used to authenticate your ``mongodump`` session

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -1121,7 +1121,7 @@ In this example:
 - The username ``myuser`` and password ``mypassword`` is used. This user
   has read access to the ``testdb``.
 - The ``admin`` database is used to authentication the user.
-- The``testdb`` is being dumped.
+- The ``testdb`` is being dumped.
 
 .. code-block:: none
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -1116,9 +1116,13 @@ Authenticating to a Specific Database With ``mongodump``
 To authenticate to a different database than the one being dumped, you 
 must specify ``authSource`` in the MongoDB URI.
 
-In this example, the ``admin` database is being used for authentication,
-and ``testdb`` is being dumped.
+In this example:
+
+- The username ``myuser`` and password ``mypassword`` is used. This user
+  has read access to the ``testdb``.
+- The ``admin`` database is used to authentication the user.
+- The``testdb`` is being dumped.
 
 .. code-block:: none
 
-   mongodump 'mongodb+srv://cluster0.example.com?authSource=admin' --db testdb
+   mongodump 'mongodb+srv://myuser:mypassword@cluster0.example.com?authSource=admin' --db testdb

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -1119,10 +1119,10 @@ must specify ``authSource`` in the MongoDB URI.
 In this example:
 
 - The username ``myuser`` and password ``mypassword`` is used. This user
-  has read access to the ``testdb``.
+  has read access to ``testdb``.
 - The ``admin`` database is used to authentication the user.
 - The ``testdb`` is being dumped.
 
 .. code-block:: none
 
-   mongodump 'mongodb+srv://myuser:mypassword@cluster0.example.com?authSource=admin' --db testdb
+   mongodump 'mongodb+srv://myuser:mypassword@cluster0.example.com/?authSource=admin' --db testdb

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -269,7 +269,7 @@ Using ``mongodump`` Without an ``authSource``
 
 When :urioption:`authSource` is not specified in the MongoDB URI, the database name provided 
 with :option:`--db` is used to authenticate your ``mongodump`` session
-and **not** indicate the database being dumped.
+and indicate the database being dumped.
 
 Restore to Matching Server Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -267,9 +267,10 @@ Behavior
 Using ``mongodump`` Without an ``authSource``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When :urioption:`authSource` is not specified in the MongoDB URI, the database name provided 
-with :option:`--db` is used to authenticate your ``mongodump`` session
-and indicate the database being dumped.
+When :urioption:`authSource` is not specified in the MongoDB URI, the 
+database name specified in :option:`--db` is used to authenticate your 
+``mongodump`` session and indicate the database being dumped. For a 
+detailed example see :ref:`mongodump-auth-dump`. 
 
 Restore to Matching Server Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1105,3 +1106,18 @@ connect to a MongoDB Atlas cluster:
 .. code-block:: none
 
    mongodump 'mongodb+srv://cluster0.example.com/testdb?authSource=$external&authMechanism=MONGODB-AWS'  <other options>
+
+.. _mongodump-auth-dump:
+
+Authenticating to a Specific Database With ``mongodump``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To authenticate to a different database than the one being dumped, you 
+must specify the ``authSource`` option.
+
+In this example, the ``admin` database is being used for authentication,
+and ``testdb`` is being dumped.
+
+.. code-block:: none
+
+   mongodump 'mongodb+srv://cluster0.example.com?authSource=admin' --db testdb

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -1121,7 +1121,7 @@ In this example:
 - The username ``myuser`` and password ``mypassword`` is used. This user
   has read access to ``testdb``.
 - The ``admin`` database is used to authenticate the user.
-- The ``testdb`` database is being dumped.
+- The ``testdb`` database is being dumped. 
 
 .. code-block:: none
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -1110,8 +1110,8 @@ connect to a MongoDB Atlas cluster:
 
 .. _mongodump-auth-dump:
 
-Authenticating to a Specific Database With ``mongodump``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Authenticating with a Specific Database With ``mongodump``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To authenticate to a different database than the one being dumped, you 
 must specify ``authSource`` in the MongoDB URI.
@@ -1120,7 +1120,7 @@ In this example:
 
 - The username ``myuser`` and password ``mypassword`` is used. This user
   has read access to ``testdb``.
-- The ``admin`` database is used to authentication the user.
+- The ``admin`` database is used to authenticate the user.
 - The ``testdb`` is being dumped.
 
 .. code-block:: none


### PR DESCRIPTION
## DESCRIPTION

Adding a behavior section to the mongodump page, that calls out providing a MongoDB URI without authSource will use the ``--db`` database for authentication purposes.

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/docsworker-xlarge/DOCS-16217/mongodump/#using-mongodump-without-an-authsource

https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/docsworker-xlarge/DOCS-16217/mongodump/#authenticating-to-a-specific-database-with-mongodump

## JIRA

https://jira.mongodb.org/browse/DOCS-16217


## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64c95b0587b3b36046013b1c

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)