### PR TITLE
DOCSP-19590 mongostat usage line

### DIFF
--- a/source/mongostat.txt
+++ b/source/mongostat.txt
@@ -25,10 +25,14 @@ Synopsis
 
 The :binary:`~bin.mongostat` utility provides a quick overview of the
 status of a currently running :binary:`~bin.mongod` or
-:binary:`~bin.mongos` instance. :binary:`~bin.mongostat` is functionally
+:binary:`~bin.mongos` instance.  Use :program:`mongostat` to help
+identify system bottlenecks.
+
+:binary:`~bin.mongostat` is functionally
 similar to the UNIX/Linux file system utility ``vmstat``, but provides
 data regarding :binary:`~bin.mongod` and :binary:`~bin.mongos`
 instances.
+
 
 .. include:: /includes/extracts/require-cmd-line-mongostat.rst
 


### PR DESCRIPTION
## DESCRIPTION

Adds minor line on what `mongostat` is used for.

## STAGING

[mongostat](https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/docsworker-xlarge/DOCSP-19590-monogstat-purpose/mongostat/#synopsis)


## JIRA

[DOCSP-19590](https://jira.mongodb.org/browse/DOCSP-19590)

## BUILD LOG
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64c1a02f87b3b3604658f9e0)


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)