### PR TITLE
DOCSP-31559 Mongorestore Index Blurb Clarification

### DIFF
--- a/source/mongorestore.txt
+++ b/source/mongorestore.txt
@@ -162,8 +162,8 @@ same value ``_id`` field as the to-be-restored documents,
 Rebuild Indexes
 ~~~~~~~~~~~~~~~
 
-:binary:`~bin.mongorestore` recreates indexes recorded by
-:binary:`~bin.mongodump` before restoring data.
+:binary:`~bin.mongorestore` recreates indexes recorded by 
+:binary:`~bin.mongodump` after restoring data.
 
 .. note::
 


### PR DESCRIPTION
## DESCRIPTION

Small correction to index rebuild blurb when using `mongorestore`.

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/docsworker-xlarge/DOCSP-31559/mongorestore/#rebuild-indexes

## JIRA

https://jira.mongodb.org/browse/DOCSP-31559


## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64ca7ffe87b3b36046467810

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)