### PR TITLE
DOCSP-17316 Update mongodump/restore Behavior

### DIFF
--- a/source/includes/fact-match-dump-restore-versions.rst
+++ b/source/includes/fact-match-dump-restore-versions.rst
@@ -19,7 +19,9 @@ see :dbcommand:`setFeatureCompatibilityVersion`.
    as the source deployment.
 
    This guarantee does not apply to metadata, archive, or oplog replay 
-   files.
+   files. If you attempt to restore these files using different 
+   source and destination versions, it could lead to failure, silent 
+   failure, or corrupted metadata.
 
 In addition, ensure that you are using the same version of 
 :binary:`~bin.mongorestore` to load the data files as the version of

--- a/source/includes/fact-match-dump-restore-versions.rst
+++ b/source/includes/fact-match-dump-restore-versions.rst
@@ -2,8 +2,8 @@ When using :binary:`~bin.mongorestore` to load data files created by
 :binary:`~bin.mongodump`, be sure that the deployment you are restoring 
 to has either:
 
-- The *same major version*.
-- The same FCV level set.
+- The same major version.
+- The same :ref:`FCV level set <set-fcv>`.
 
 For example, if your dump was created from a MongoDB deployment running
 version ``4.4.x``, be sure that the MongoDB deployment you are restoring 
@@ -12,11 +12,12 @@ to is also running version ``4.4.x`` or has the FCV level set to
 
 .. note::
 
-   The BSON files generated from ``mongodump`` will be restorable 
+   The BSON files generated from ``mongodump`` are restorable 
    into MongoDB deployments starting with the version they were created 
-   on and in all future versions of the server.
+   on and in all future versions.
 
-   This guarantee does not apply to metadata, archive, or oplog replay files.
+   This guarantee does not apply to metadata, archive, or oplog replay 
+   files.
 
 In addition, ensure that you are using the same version of 
 :binary:`~bin.mongorestore` to load the data files as the version of

--- a/source/includes/fact-match-dump-restore-versions.rst
+++ b/source/includes/fact-match-dump-restore-versions.rst
@@ -1,9 +1,22 @@
 When using :binary:`~bin.mongorestore` to load data files created by
-:binary:`~bin.mongodump`, be sure that you are restoring to the *same
-major version* of the MongoDB Server that the files were created from.
-For example, if your dump was created from a MongoDB Server running
-version ``4.4.x``, be sure that the MongoDB Server you are restoring to
-is also running version ``4.4.x``.
+:binary:`~bin.mongodump`, be sure that the deployment you are restoring 
+to has either:
+
+- The *same major version*.
+- The same FCV level set.
+
+For example, if your dump was created from a MongoDB deployment running
+version ``4.4.x``, be sure that the MongoDB deployment you are restoring 
+to is also running version ``4.4.x`` or has the FCV level set to 
+``4.4.x``.
+
+.. note::
+
+   The BSON files generated from ``mongodump`` will be restorable 
+   into MongoDB deployments starting with the version they were created 
+   on and in all future versions of the server.
+
+   This guarantee does not apply to metadata, archive, or oplog replay files.
 
 In addition, ensure that you are using the same version of 
 :binary:`~bin.mongorestore` to load the data files as the version of

--- a/source/includes/fact-match-dump-restore-versions.rst
+++ b/source/includes/fact-match-dump-restore-versions.rst
@@ -7,10 +7,10 @@ destination deployments must be either:
 
 For example, if your dump was created from a MongoDB deployment running
 version ``4.4``, the MongoDB deployment you restore to must also run 
-version ``4.4`` or have its FCV level set to ``4.4``.
+version ``4.4`` or have its FCV set to ``4.4``.
 
-For information on changing feature compatibility versions, 
-see :dbcommand:`setFeatureCompatibilityVersion`.
+To change your feature compatibility version, see 
+:dbcommand:`setFeatureCompatibilityVersion`.
 
 .. note::
 

--- a/source/includes/fact-match-dump-restore-versions.rst
+++ b/source/includes/fact-match-dump-restore-versions.rst
@@ -3,12 +3,15 @@ When using :binary:`~bin.mongorestore` to load data files created by
 to has either:
 
 - The same major version.
-- The same :ref:`FCV level set <set-fcv>`.
+- The same feature compatibility version. 
 
 For example, if your dump was created from a MongoDB deployment running
-version ``4.4.x``, be sure that the MongoDB deployment you are restoring 
-to is also running version ``4.4.x`` or has the FCV level set to 
-``4.4.x``.
+version ``4.4``, be sure that the MongoDB deployment you are restoring 
+to is also running version ``4.4`` or has the FCV level set to 
+``4.4``. 
+
+See :dbcommand:`setFeatureCompatibilityVersion` for 
+information on changing feature compatibility versions.
 
 .. note::
 

--- a/source/includes/fact-match-dump-restore-versions.rst
+++ b/source/includes/fact-match-dump-restore-versions.rst
@@ -19,9 +19,10 @@ see :dbcommand:`setFeatureCompatibilityVersion`.
    as the source deployment.
 
    This guarantee does not apply to metadata, archive, or oplog replay 
-   files. If you attempt to restore these files using different 
-   source and destination deployment versions, it could lead to failure, 
-   silent failure, or corrupted metadata.
+   files. If you try to restore these files using different 
+   source and destination deployment versions, the ``mongorestore`` 
+   process could result in failure, silent failure, or corrupted 
+   metadata.
 
 In addition, ensure that you are using the same version of 
 :binary:`~bin.mongorestore` to load the data files as the version of

--- a/source/includes/fact-match-dump-restore-versions.rst
+++ b/source/includes/fact-match-dump-restore-versions.rst
@@ -20,8 +20,8 @@ see :dbcommand:`setFeatureCompatibilityVersion`.
 
    This guarantee does not apply to metadata, archive, or oplog replay 
    files. If you attempt to restore these files using different 
-   source and destination versions, it could lead to failure, silent 
-   failure, or corrupted metadata.
+   source and destination deployment versions, it could lead to failure, 
+   silent failure, or corrupted metadata.
 
 In addition, ensure that you are using the same version of 
 :binary:`~bin.mongorestore` to load the data files as the version of

--- a/source/includes/fact-match-dump-restore-versions.rst
+++ b/source/includes/fact-match-dump-restore-versions.rst
@@ -1,23 +1,22 @@
 When using :binary:`~bin.mongorestore` to load data files created by
-:binary:`~bin.mongodump`, be sure that the deployment you are restoring 
-to has either:
+:binary:`~bin.mongodump`, the MongoDB versions of your source and 
+destination deployments must be either:
 
 - The same major version.
 - The same feature compatibility version. 
 
 For example, if your dump was created from a MongoDB deployment running
-version ``4.4``, be sure that the MongoDB deployment you are restoring 
-to is also running version ``4.4`` or has the FCV level set to 
-``4.4``. 
+version ``4.4``, the MongoDB deployment you restore to must also run 
+version ``4.4`` or have its FCV level set to ``4.4``.
 
-See :dbcommand:`setFeatureCompatibilityVersion` for 
-information on changing feature compatibility versions.
+For information on changing feature compatibility versions, 
+see :dbcommand:`setFeatureCompatibilityVersion`.
 
 .. note::
 
-   The BSON files generated from ``mongodump`` are restorable 
-   into MongoDB deployments starting with the version they were created 
-   on and in all future versions.
+   You can restore the BSON files generated from ``mongodump``
+   into MongoDB deployments running the same or newer version 
+   as the source deployment.
 
    This guarantee does not apply to metadata, archive, or oplog replay 
    files.


### PR DESCRIPTION
## DESCRIPTION

Updating include file on the mongodump/restore page that clarifys version requirements when dumping and restoring from MongoDB deployment versions.

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/docsworker-xlarge/DOCSP-17316/mongodump/#restore-to-matching-server-version

## JIRA

https://jira.mongodb.org/browse/DOCSP-17316

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64d25dc767dbe91010e89824

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)