### PR TITLE
DOCSP-32381 Updates --quiet option for mongodump and mongoexport

### DIFF
--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -421,15 +421,14 @@ Options
 
    This option suppresses:
    
-   - output from :term:`database commands <database command>`
+   - Output from :term:`database commands <database command>`
    
-   - replication activity
+   - Replication activity
    
-   - connection accepted events
-   
-   - connection closed events
+   - Connection accepted and closed events
 
-   - error messages
+   - All logs, including error messages, except for those that occur when
+     parsing options
 
 .. option:: --version
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -429,6 +429,8 @@ Options
    
    - connection closed events
 
+   - error messages
+
 .. option:: --version
 
    Returns the :program:`mongodump` release number.

--- a/source/mongoexport.txt
+++ b/source/mongoexport.txt
@@ -329,15 +329,14 @@ Options
 
    This option suppresses:
    
-   - output from :term:`database commands <database command>`
+   - Output from :term:`database commands <database command>`
    
-   - replication activity
+   - Replication activity
    
-   - connection accepted events
-   
-   - connection closed events
+   - Connection accepted and closed events
 
-   - error messages
+   - All logs, including error messages, except for those that occur when
+     parsing options
 
 
 .. option:: --version

--- a/source/mongoexport.txt
+++ b/source/mongoexport.txt
@@ -337,6 +337,8 @@ Options
    
    - connection closed events
 
+   - error messages
+
 
 .. option:: --version
 


### PR DESCRIPTION
## DESCRIPTION

Updates suppressed message list for `--quiet` option on `mongodump` and `mongoexport`.

## STAGING

* [mongoexport](https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/docsworker-xlarge/DOCSP-32381-mongodump-quiet/mongoexport/#std-option-mongoexport.--quiet)
* [mongodump](https://docs-mongodbcom-staging.corp.mongodb.com/database-tools/docsworker-xlarge/DOCSP-32381-mongodump-quiet/mongodump/#std-option-mongodump.--quiet)


## JIRA
* [DOCSP-32381](https://jira.mongodb.org/browse/DOCSP-32381)


## BUILD LOG

* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64e3e93c57e37806c50dcb99)
* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64f258c224fcc731b48cb498)


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)