### PR TITLE
DOCSP 33804 - removing read preference warning

### DIFF
--- a/source/includes/warning-read-preference-mongos.rst
+++ b/source/includes/warning-read-preference-mongos.rst
@@ -1,5 +1,0 @@
-.. warning::
- 
-   Using a :ref:`read preference<replica-set-read-preference>` other than 
-   :readmode:`primary` with a connection to a :binary:`~bin.mongos` may produce
-   inconsistencies, duplicates, or result in missed documents. 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -757,8 +757,6 @@ Options
    :option:`--uri connection string <--uri>`, the command-line
    :option:`--readPreference` overrides the read preference specified in
    the URI string.
-   
-   .. include:: /includes/warning-read-preference-mongos.rst
 
 .. option:: --gzip
    

--- a/source/mongoexport.txt
+++ b/source/mongoexport.txt
@@ -796,8 +796,6 @@ Options
    :option:`--uri connection string <--uri>`, the command-line
    :option:`--readPreference` overrides the read preference specified in
    the URI string.
-   
-   .. include:: /includes/warning-read-preference-mongos.rst
 
 
 .. option:: --skip=<number>

--- a/source/mongofiles.txt
+++ b/source/mongofiles.txt
@@ -513,9 +513,6 @@ Options
    :option:`--uri connection string <--uri>`, the command-line
    :option:`--readPreference` overrides the read preference specified in
    the URI string.
-   
-   .. include:: /includes/warning-read-preference-mongos.rst
-
 
 .. _mongofiles-commands:
 


### PR DESCRIPTION
## DESCRIPTION

Removing warning about read preferences

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/database-tools/DOCSP-33804/mongodump/#std-option-mongodump.--readPreference
https://preview-mongodbltranmdb2.gatsbyjs.io/database-tools/DOCSP-33804/mongoexport/#std-option-mongoexport.--readPreference
https://preview-mongodbltranmdb2.gatsbyjs.io/database-tools/DOCSP-33804/mongofiles/#std-option-mongofiles.--readPreference

## JIRA

https://jira.mongodb.org/browse/DOCSP-33804

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6532bc1e3ede3ec111a41e18

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)