### PR TITLE
Docsp 33929 list 7.0 support for mongoimport

### DIFF
--- a/source/includes/extracts-compatibility.yaml
+++ b/source/includes/extracts-compatibility.yaml
@@ -20,6 +20,7 @@ content: |
    |tool-binary| version ``{+release+}`` supports the following versions
    of the MongoDB Server:
 
+   - MongoDB 7.0
    - MongoDB 6.0
    - MongoDB 5.0
    - MongoDB 4.4

--- a/source/includes/extracts-compatibility.yaml
+++ b/source/includes/extracts-compatibility.yaml
@@ -8,6 +8,7 @@ content: |
    - MongoDB 6.0
    - MongoDB 5.0
    - MongoDB 4.4
+   - MongoDB 4.2
 
    While the tools may work on earlier versions of MongoDB server, any
    such compatibility is not guaranteed.
@@ -23,6 +24,7 @@ content: |
    - MongoDB 6.0
    - MongoDB 5.0
    - MongoDB 4.4
+   - MongoDB 4.2
 
    While |tool-binary| may work on earlier versions of MongoDB server,
    any such compatibility is not guaranteed.

--- a/source/includes/extracts-compatibility.yaml
+++ b/source/includes/extracts-compatibility.yaml
@@ -8,7 +8,6 @@ content: |
    - MongoDB 6.0
    - MongoDB 5.0
    - MongoDB 4.4
-   - MongoDB 4.2
 
    While the tools may work on earlier versions of MongoDB server, any
    such compatibility is not guaranteed.
@@ -24,7 +23,6 @@ content: |
    - MongoDB 6.0
    - MongoDB 5.0
    - MongoDB 4.4
-   - MongoDB 4.2
 
    While |tool-binary| may work on earlier versions of MongoDB server,
    any such compatibility is not guaranteed.

--- a/source/mongoimport.txt
+++ b/source/mongoimport.txt
@@ -50,6 +50,12 @@ tool.
 Versioning
 ~~~~~~~~~~
 
+.. include:: /includes/extracts/dbtools-version-single.rst
+
+.. note:: Quick links to older documentation
+
+   - :v4.2:`MongoDB 4.2 mongoimport </reference/program/mongoimport>`
+
 This documentation is for version ``{+release+}`` of |tool-binary|. 
 
 Compatibility
@@ -331,7 +337,9 @@ Options
 .. option:: --sslAllowInvalidCertificates
 
    Bypasses the validation checks for server certificates and allows
-   the use of invalid certificates. MongoDB logs a warning for invalid certificates.
+   the use of invalid certificates. When using the
+   :setting:`~net.ssl.allowInvalidCertificates` setting, MongoDB logs a
+   warning for invalid certificates.
    
    .. include:: /includes/extracts/ssl-facts-invalid-cert-warning-clients.rst
    

--- a/source/mongoimport.txt
+++ b/source/mongoimport.txt
@@ -114,7 +114,7 @@ Encoding
 ~~~~~~~~
 
 :binary:`~bin.mongoimport` only supports data files that are UTF-8 encoded.
-Using other encodings will produce errors.
+Using other encodings produces errors.
 
 FIPS
 ~~~~
@@ -305,12 +305,11 @@ Options
 
    Specifies the password to de-crypt the certificate-key file (i.e.
    :option:`--sslPEMKeyFile`). Use the :option:`--sslPEMKeyPassword` option only if the
-   certificate-key file is encrypted. In all cases, the :program:`mongoimport` will
-   redact the password from all logging and reporting output.
+   certificate-key file is encrypted. In all cases, the :program:`mongoimport` redacts the password from all logging and reporting output.
    
    If the private key in the PEM file is encrypted and you do not specify
-   the :option:`--sslPEMKeyPassword` option, the :program:`mongoimport` will prompt for a passphrase. See
-   :ref:`ssl-certificate-password`.
+   the :option:`--sslPEMKeyPassword` option, the :program:`mongoimport` 
+   prompts for a passphrase. See :ref:`ssl-certificate-password`.
    
    .. include:: /includes/extracts/uri-used-with-sslpemkeypassword.rst
 
@@ -332,9 +331,7 @@ Options
 .. option:: --sslAllowInvalidCertificates
 
    Bypasses the validation checks for server certificates and allows
-   the use of invalid certificates. When using the
-   :setting:`~net.ssl.allowInvalidCertificates` setting, MongoDB logs as a
-   warning the use of the invalid certificate.
+   the use of invalid certificates. MongoDB logs a warning for invalid certificates.
    
    .. include:: /includes/extracts/ssl-facts-invalid-cert-warning-clients.rst
    
@@ -461,7 +458,7 @@ Options
    :option:`--fields` with :option:`--columnsHaveTypes`.
 
    If you attempt to include :option:`--fields` when importing JSON data,
-   :program:`mongoimport` will return an error. :option:`--fields` is only for :term:`CSV`
+   :program:`mongoimport` returns an error. :option:`--fields` is only for :term:`CSV`
    or :term:`TSV` imports.
 
 
@@ -476,7 +473,7 @@ Options
    :option:`--fieldFile` with :option:`--columnsHaveTypes`.
 
    If you attempt to include :option:`--fieldFile` when importing JSON data,
-   :program:`mongoimport` will return an error. :option:`--fieldFile` is only for :term:`CSV`
+   :program:`mongoimport` returns an error. :option:`--fieldFile` is only for :term:`CSV`
    or :term:`TSV` imports.
 
 
@@ -488,7 +485,7 @@ Options
    
 
    If you attempt to include :option:`--ignoreBlanks` when importing JSON data,
-   :program:`mongoimport` will return an error. :option:`--ignoreBlanks` is only for :term:`CSV`
+   :program:`mongoimport` returns an error. :option:`--ignoreBlanks` is only for :term:`CSV`
    or :term:`TSV` imports.
 
 
@@ -524,12 +521,12 @@ Options
 
    If using :option:`--type csv <mongoimport --type>` or :option:`--type
    tsv <mongoimport --type>`, uses the first line as field names.
-   Otherwise, :binary:`~bin.mongoimport` will import the first line as a
+   Otherwise, :binary:`~bin.mongoimport` imports the first line as a
    distinct document.
    
 
    If you attempt to include :option:`--headerline` when importing JSON data,
-   :program:`mongoimport` will return an error. :option:`--headerline` is only for :term:`CSV`
+   :program:`mongoimport` returns an error. :option:`--headerline` is only for :term:`CSV`
    or :term:`TSV` imports.
 
 
@@ -570,7 +567,7 @@ Options
    is interpreted as a document key, and not an array index.
 
    If using the :option:`--ignoreBlanks` option with
-   :option:`--useArrayIndexFields`, :program:`mongoimport` will log an
+   :option:`--useArrayIndexFields`, :program:`mongoimport` returns an
    error if you attempt to import a document that contains a
    blank value (e.g. ``""``) for an array index field.
 
@@ -601,23 +598,23 @@ Options
    
       * - ``insert``
    
-        - Insert the documents in the import file. :program:`mongoimport` will log
-          an error if you attempt to import a document that contains a
-          duplicate value for a field with a :ref:`unique index
-          <index-type-unique>`, such as ``_id``.
+        - Insert the documents in the import file.
+          :program:`mongoimport` returns an error if you attempt to
+          import a document that contains a duplicate value for a field
+          with a :ref:`unique index <index-type-unique>`, such as ``_id``.
    
       * - ``upsert``
    
         - Replace existing documents in the database with matching
           documents from the
-          import file. :program:`mongoimport` will insert all other
+          import file. :program:`mongoimport` inserts all other
           documents. :ref:`ex-mongoimport-upsert` describes how to
           use :option:`--mode` ``upsert``.
    
       * - ``merge``
    
         - Merge existing documents that match a document in the import file with
-          the new document. :program:`mongoimport` will insert all other documents.
+          the new document. :program:`mongoimport` inserts all other documents.
           :ref:`ex-mongoimport-merge` describes how to use :option:`--mode`
           ``merge``.
 
@@ -643,7 +640,7 @@ Options
    another field or field combination can uniquely identify
    documents as a basis for performing upsert operations.
 
-   If you do not specify a field, :option:`--upsertFields` will upsert
+   If you do not specify a field, :option:`--upsertFields` upserts
    on the basis of the ``_id`` field.
 
    To ensure adequate performance, indexes should exist for the
@@ -835,7 +832,7 @@ Options
    See :ref:`example-csv-import-types` for sample usage.
 
    If you attempt to include :option:`--columnsHaveTypes` when importing JSON data,
-   :program:`mongoimport` will return an error. :option:`--columnsHaveTypes` is only for :term:`CSV`
+   :program:`mongoimport` returns an error. :option:`--columnsHaveTypes` is only for :term:`CSV`
    or :term:`TSV` imports.
 
 
@@ -1034,7 +1031,7 @@ the fields to match against.
 .. note::
 
    With :option:`--mode <mongoimport --mode>` ``delete``,
-   :binary:`~bin.mongoimport` will only delete one existing document per
+   :binary:`~bin.mongoimport` only deletes one existing document per
    match. Ensure that documents from the import file match a single
    existing document from the database.
 
@@ -1251,9 +1248,8 @@ shell:
    export AWS_SECRET_ACCESS_KEY='<aws secret access key>'
    export AWS_SESSION_TOKEN='<aws session token>'
 
-Syntax for setting environment variables in other shells will be
-different. Consult the documentation for your platform for more
-information.
+Other shells use different syntax to set environment variables. Consult
+the documentation for your platform for more information.
 
 You can verify that these environment variables have been set with the
 following command:

--- a/source/mongoimport.txt
+++ b/source/mongoimport.txt
@@ -50,8 +50,6 @@ tool.
 Versioning
 ~~~~~~~~~~
 
-.. include:: /includes/extracts/dbtools-version-single.rst
-
 This documentation is for version ``{+release+}`` of |tool-binary|. 
 
 Compatibility

--- a/source/mongoimport.txt
+++ b/source/mongoimport.txt
@@ -52,11 +52,6 @@ Versioning
 
 .. include:: /includes/extracts/dbtools-version-single.rst
 
-.. note:: Quick links to older documentation
-
-   - :v4.2:`MongoDB 4.2 mongoimport </reference/program/mongoimport>`
-   - :v4.0:`MongoDB 4.0 mongoimport </reference/program/mongoimport>`
-
 This documentation is for version ``{+release+}`` of |tool-binary|. 
 
 Compatibility

--- a/source/mongoimport.txt
+++ b/source/mongoimport.txt
@@ -76,7 +76,7 @@ Installation
 Syntax
 ------
 
-The :binary:`~bin.mongoimport` command has the following form:
+The :binary:`~bin.mongoimport` command has the following syntax:
 
 .. code-block:: sh
 
@@ -446,7 +446,7 @@ Options
 .. option:: --collection=<collection>, -c=<collection>
 
    Specifies the collection to import. If you do not specify
-   :option:`--collection`, :binary:`~bin.mongoimport` takes the
+   :option:`--collection`, :binary:`~bin.mongoimport` reads the
    collection name from the input filename, omitting the file's
    extension if it has one.
 
@@ -1140,7 +1140,7 @@ either: :option:`--fields <mongoimport --fields>`, :option:`--fieldFile
 Specify field names and data types in the form
 ``<colName>.<type>(<arg>)``. 
 
-For example, a ``/example/file.csv`` file contains the following data:
+For example, ``/example/file.csv`` contains the following data:
 
 .. code-block:: none
 


### PR DESCRIPTION
## DESCRIPTION

- mongoimport doesn't list support for 7.0
- removed mentions of support for 4.0

## STAGING
[mongoimport](https://preview-mongodbnvillahermosamdb.gatsbyjs.io/database-tools/DOCSP-33929-list-7.0-support-for-mongoimport/mongoimport/)

## JIRA
https://jira.mongodb.org/browse/DOCSP-33929

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6543e730bd8a7a957949e460

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)