### PR TITLE
DOCSP-33881 mongdump $regex example

### DIFF
--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -710,7 +710,7 @@ Options
 
    .. code-block:: sh 
 
-      mongodump -d=sample_mflix -c=movies  -q='{"year": {"$regex": "20"}}'
+      mongodump -d=sample_mflix -c=movies  -q='{ "year": { "$regex": "20" } }'
 
    .. note::
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -710,7 +710,7 @@ Options
 
    .. code-block:: sh 
 
-      mongodump -d=sample_mflix -c=movies  -q='{ "year": { "$regex": "20" } }'
+      mongodump -d=sample_mflix -c=movies -q='{ "year": { "$regex": "20" } }'
 
    .. note::
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -706,6 +706,12 @@ Options
 
       mongodump -d=test -c=records -q='{ "a": { "$gte": 3 }, "date": { "$lt": { "$date": "2016-01-01T00:00:00.000Z" } } }'
 
+   To use :query:`$regex` with ``mongodump``, use the following syntax: 
+
+   .. code-block:: sh 
+
+      mongodump -d=sample_mflix -c=movies  -q='{"year": {"$regex": "20"}}'
+
    .. note::
 
       When you use the ``--query`` option on a :ref:`time series


### PR DESCRIPTION
## DESCRIPTION
Adds `$regex` syntax example to `mongodump` page

## STAGING
https://preview-mongodbajhuhmdb.gatsbyjs.io/database-tools/DOCSP-33881-mongodump-regex-syntax/mongodump/#std-option-mongodump.--query

## JIRA
https://jira.mongodb.org/browse/DOCSP-33881

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=655528685b686d6bd9b0d365

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)