### PR TITLE
DOCS-16186: Add GO compiler info to changelog for 100.7.1

### DIFF
--- a/source/includes/changelogs/releases/100.7.1.rst
+++ b/source/includes/changelogs/releases/100.7.1.rst
@@ -11,6 +11,8 @@ This release fixes a few bugs and adds downloads for the following platforms:
 - RedHat Enterprise Linux 9 (x86 and ARM)
 - Amazon Linux 2023 (x86 and ARM)
 
+Downloads were compiled with Go 1.19.9.
+
 Bug
 ~~~
 

--- a/source/includes/changelogs/releases/100.7.1.rst
+++ b/source/includes/changelogs/releases/100.7.1.rst
@@ -11,7 +11,7 @@ This release fixes a few bugs and adds downloads for the following platforms:
 - RedHat Enterprise Linux 9 (x86 and ARM)
 - Amazon Linux 2023 (x86 and ARM)
 
-Downloads were compiled with Go 1.19.9.
+The tools were compiled with Go 1.19.9.
 
 Bug
 ~~~


### PR DESCRIPTION
## DESCRIPTION
Add Go compiler version to 100.7.1 changelogs. 

## STAGING
https://preview-mongodbsaraholsonmongodb.gatsbyjs.io/database-tools/DOCS-16185/release-notes/database-tools-changelog/#100.7.1-changelog

## JIRA
https://jira.mongodb.org/browse/DOCS-16185

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65bc45c06b2f17c95aed7ef2

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)