### PR TITLE
DOCSP-35356 field reordering 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "esbonio.sphinx.confDir": ""
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "esbonio.sphinx.confDir": ""
-}

--- a/source/includes/changelogs/releases/100.9.1.rst
+++ b/source/includes/changelogs/releases/100.9.1.rst
@@ -5,12 +5,19 @@
 
 *Released 2023-11-09*
 
-This version updates external dependencies and fixes an issue where
-mongodump could change the ordering of fields in a view definition.
+This version updates external dependencies and fixes an issue where mongodump 
+could change the ordering of fields in a view definition. View pipelines and 
+schema validation are the only collection options sensitive to field ordering.
+Depending on the contents of the view or validator options, the following can 
+change:
+- The set of results returned by a view, or 
+- The criteria determining which documents are accepted by a validator.
+
+Not all view pipelines or schema validations are affected by key reordering. 
 
 Bug
 ~~~
 
 - :issue:`TOOLS-3367` Building fails: failed to detect local platform from kernel name
 - :issue:`TOOLS-3388` mongodb/mongo-tools master :go.mod - Denial of Service DoS in golang.org/x/net
-- :issue:`TOOLS-3411` MongoDump does not maintain field-order for sort and match in Views
+- :issue:`TOOLS-3411` MongoDump does not maintain field-order for sort and match in Views.

--- a/source/includes/changelogs/releases/100.9.1.rst
+++ b/source/includes/changelogs/releases/100.9.1.rst
@@ -12,7 +12,7 @@ to field ordering. Depending on the contents of the view or validator options,
 the following can change:
 
 - The set of results returned by a view, or
-- The criteria determining which documents are accepted by a validator.
+- The criteria that determines which documents are accepted by a validator.
 
 Not all view pipelines or schema validations are affected by key reordering. 
 

--- a/source/includes/changelogs/releases/100.9.1.rst
+++ b/source/includes/changelogs/releases/100.9.1.rst
@@ -10,7 +10,8 @@ could change the ordering of fields in a view definition. View pipelines and
 schema validation are the only collection options sensitive to field ordering.
 Depending on the contents of the view or validator options, the following can 
 change:
-- The set of results returned by a view, or 
+
+- The set of results returned by a view, or
 - The criteria determining which documents are accepted by a validator.
 
 Not all view pipelines or schema validations are affected by key reordering. 

--- a/source/includes/changelogs/releases/100.9.1.rst
+++ b/source/includes/changelogs/releases/100.9.1.rst
@@ -6,10 +6,10 @@
 *Released 2023-11-09*
 
 This version updates external dependencies and fixes an issue where mongodump 
-could change the ordering of fields in a view definition. View pipelines and 
-schema validation are the only collection options sensitive to field ordering.
-Depending on the contents of the view or validator options, the following can 
-change:
+could change the ordering of fields in a view definition (:issue:`TOOLS-3411`). 
+View pipelines and schema validation are the only collection options sensitive 
+to field ordering. Depending on the contents of the view or validator options, 
+the following can change:
 
 - The set of results returned by a view, or
 - The criteria determining which documents are accepted by a validator.


### PR DESCRIPTION
## DESCRIPTION
Add warning to 100.9.1 changelog regarding field reordering for view pipelines and schema validations. 

## STAGING
https://preview-mongodbjocelynmendez1.gatsbyjs.io/database-tools/DOCSP-35356/release-notes/database-tools-changelog/#100.9.1-changelog

## JIRA
https://jira.mongodb.org/browse/DOCSP-35356

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65c53c416b2f17c95a46df36

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)