### PR TITLE
DOCSP-15886 doc limitations with shared clusters

### DIFF
--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -372,6 +372,21 @@ FIPS
 connections to a :binary:`~bin.mongod`/:binary:`~bin.mongos` that is
 :manual:`configured to use FIPS mode </tutorial/configure-fips>`.
 
+Using ``mongodump`` on Atlas Cluster 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On free (``M0``) and shared (``M2`` and ``M5``) tier Atlas clusters, the
+following limitations apply: 
+
+- You can't run ``mongodump`` on the ``admin`` database. If you use the
+  :option:`--db <mongodump --db>` option to set the destination database
+  to ``admin``, the program returns an error. 
+
+- You can't use the following options with the ``mongodump`` program:
+
+  - :option:`--dumpDbUsersAndRoles`
+  - :option:`--oplog <mongodump --oplog>`
+
 Required Access
 ---------------
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -372,8 +372,8 @@ FIPS
 connections to a :binary:`~bin.mongod`/:binary:`~bin.mongos` that is
 :manual:`configured to use FIPS mode </tutorial/configure-fips>`.
 
-Using ``mongodump`` on Atlas Cluster 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using ``mongodump`` on Atlas Clusters 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 On free (``M0``) and shared (``M2`` and ``M5``) tier Atlas clusters, the
 following limitations apply: 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -372,8 +372,8 @@ FIPS
 connections to a :binary:`~bin.mongod`/:binary:`~bin.mongos` that is
 :manual:`configured to use FIPS mode </tutorial/configure-fips>`.
 
-Using ``mongodump`` on Atlas Clusters 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using ``mongodump`` on Atlas Free and Shared Tier Clusters 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 On free (``M0``) and shared (``M2`` and ``M5``) tier Atlas clusters, the
 following limitations apply: 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -378,9 +378,10 @@ Using ``mongodump`` on Atlas Free and Shared Tier Clusters
 On free (``M0``) and shared (``M2`` and ``M5``) tier Atlas clusters, the
 following limitations apply: 
 
-- You can't run ``mongodump`` on the ``admin`` database. If you use the
-  :option:`--db <mongodump --db>` option to set the destination database
-  to ``admin``, the program returns an error. 
+- You can't run ``mongodump`` on the ``admin`` database. By default,
+  ``mongodump`` skips this database. If you use the :option:`--db
+  <mongodump --db>` option to set the destination database to ``admin``,
+  the program returns an error.
 
 - You can't use the following options with the ``mongodump`` program:
 

--- a/source/mongorestore.txt
+++ b/source/mongorestore.txt
@@ -221,10 +221,10 @@ Using ``mongorestore`` on Atlas Free and Shared Tier Clusters
 On free (``M0``) and shared (``M2`` and ``M5``) tier Atlas clusters, the
 following limitations apply:
 
-- You can't run ``mongorestore`` on the ``admin`` database. If you use
-  the :option:`--db <mongorestore --db>` option to set the destination
-  database to ``admin``, the program returns an error. By default,
-  ``mongorestore`` skips this database.
+- You can't run ``mongorestore`` on the ``admin`` database. By default,
+  ``mongorestore`` skips this database. If you use the :option:`--db
+  <mongorestore --db>` option to set the destination database to
+  ``admin``, the program returns an error.
 
 - You can't use the following options with the ``mongorestore`` program:
 

--- a/source/mongorestore.txt
+++ b/source/mongorestore.txt
@@ -224,7 +224,7 @@ following limitations apply:
 - You can't run ``mongorestore`` on the ``admin`` database. If you use
   the :option:`--db <mongorestore --db>` option to set the destination
   database to ``admin``, the program returns an error. By default,
-  ``mongorestore`` skips this option.
+  ``mongorestore`` skips this database.
 
 - You can't use the following options with the ``mongorestore`` program:
 

--- a/source/mongorestore.txt
+++ b/source/mongorestore.txt
@@ -215,6 +215,22 @@ Starting in MongoDB 5.0, you can use ``mongorestore`` to restore
 :ref:`timeseries collections <manual-timeseries-landing>`.
 For details, see :ref:`mongorestore-example-time-series`.
 
+Using ``mongorestore`` on Atlas Cluster 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On free (``M0``) and shared (``M2`` and ``M5``) tier Atlas clusters, the
+following limitations apply:
+
+- You can't run ``mongorestore`` on the ``admin`` database. If you use
+  the :option:`--db <mongorestore --db>` option to set the destination
+  database to ``admin``, the program returns an error. 
+
+- You can't use the following options with the ``mongorestore`` program:
+
+  - :option:`--restoreDbUsersAndRoles`
+  - :option:`--oplogReplay <mongorestore --oplogReplay>`
+  - :option:`--preserveUUID <mongorestore --preserveUUID>`
+
 .. _mongorestore-required-access:
 
 Required Access

--- a/source/mongorestore.txt
+++ b/source/mongorestore.txt
@@ -215,8 +215,8 @@ Starting in MongoDB 5.0, you can use ``mongorestore`` to restore
 :ref:`timeseries collections <manual-timeseries-landing>`.
 For details, see :ref:`mongorestore-example-time-series`.
 
-Using ``mongorestore`` on Atlas Cluster 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using ``mongorestore`` on Atlas Clusters 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 On free (``M0``) and shared (``M2`` and ``M5``) tier Atlas clusters, the
 following limitations apply:

--- a/source/mongorestore.txt
+++ b/source/mongorestore.txt
@@ -215,15 +215,16 @@ Starting in MongoDB 5.0, you can use ``mongorestore`` to restore
 :ref:`timeseries collections <manual-timeseries-landing>`.
 For details, see :ref:`mongorestore-example-time-series`.
 
-Using ``mongorestore`` on Atlas Clusters 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using ``mongorestore`` on Atlas Free and Shared Tier Clusters 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 On free (``M0``) and shared (``M2`` and ``M5``) tier Atlas clusters, the
 following limitations apply:
 
 - You can't run ``mongorestore`` on the ``admin`` database. If you use
   the :option:`--db <mongorestore --db>` option to set the destination
-  database to ``admin``, the program returns an error. 
+  database to ``admin``, the program returns an error. By default,
+  ``mongorestore`` skips this option.
 
 - You can't use the following options with the ``mongorestore`` program:
 


### PR DESCRIPTION
## DESCRIPTION
Adds documentation for mongodump and mongorestore limitations with free and shared Atlas clusters

## STAGING

- https://preview-mongodbkanchanamongodb.gatsbyjs.io/database-tools/DOCS-15886/mongodump/#using-mongodump-on-atlas-cluster
- https://preview-mongodbkanchanamongodb.gatsbyjs.io/database-tools/DOCS-15886/mongorestore/#using-mongorestore-on-atlas-cluster


## JIRA
https://jira.mongodb.org/browse/DOCS-15886

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65c5568e6b2f17c95a52c551

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)