### PR TITLE
DOCS-15555 mongorestore fails to copy/clone an existing database to a new one

### DIFF
--- a/source/includes/extracts-clone-copy-db-examples.yaml
+++ b/source/includes/extracts-clone-copy-db-examples.yaml
@@ -19,7 +19,7 @@ content: |
 
       .. code-block:: sh
 
-         mongorestore --archive="mongodump-test-db" --nsFrom="test.*" --nsTo="examples.*'"
+         mongorestore --archive="mongodump-test-db" --nsFrom="test.*" --nsTo="examples.*"
 
    .. tip::
 

--- a/source/includes/extracts-clone-copy-db-examples.yaml
+++ b/source/includes/extracts-clone-copy-db-examples.yaml
@@ -19,7 +19,7 @@ content: |
 
       .. code-block:: sh
 
-         mongorestore --archive="mongodump-test-db" --nsFrom='test.*' --nsTo='examples.*'
+         mongorestore --archive="mongodump-test-db" --nsFrom="test.*" --nsTo="examples.*'"
 
    .. tip::
 
@@ -33,5 +33,5 @@ content: |
 
    .. code-block:: sh
 
-      mongodump --archive --db=test | mongorestore --archive  --nsFrom='test.*' --nsTo='examples.*'  
+      mongodump --archive --db=test | mongorestore --archive  --nsFrom="test.*" --nsTo="examples.*"  
 ...

--- a/source/mongorestore.txt
+++ b/source/mongorestore.txt
@@ -1176,7 +1176,7 @@ namespaces. The following operation
 
 .. code-block:: sh
 
-   mongorestore --nsInclude='data.*' --nsFrom='data.$prefix$_$customer$' --nsTo='$customer$.$prefix$'
+   mongorestore --nsInclude='data.*' --nsFrom="data.$prefix$_$customer$" --nsTo="$customer$.$prefix$"
 
 .. _mongorestore-example-copy-clone-database:
 
@@ -1254,7 +1254,7 @@ options with the ``--gzip`` option.
 
 .. code-block:: sh
 
-   mongorestore --gzip --nsFrom='data.$prefix$_$customer$' --nsTo='$customer$.$prefix$'
+   mongorestore --gzip --nsFrom="data.$prefix$_$customer$" --nsTo="$customer$.$prefix$"
 
 .. _mongorestore-example-archive-stdin:
 
@@ -1327,7 +1327,7 @@ namespace:
 
 .. code-block:: sh
 
-   mongorestore --host localhost --port 27017 --nsFrom='test.*' --nsTo='mongorestore.*' dump/
+   mongorestore --host localhost --port 27017 --nsFrom="test.*" --nsTo="mongorestore.*" dump/
 
 .. note::
 

--- a/source/mongorestore.txt
+++ b/source/mongorestore.txt
@@ -1176,7 +1176,7 @@ namespaces. The following operation
 
 .. code-block:: sh
 
-   mongorestore --nsInclude='data.*' --nsFrom="data.$prefix$_$customer$" --nsTo="$customer$.$prefix$"
+   mongorestore --nsInclude="data.*" --nsFrom="data.$prefix$_$customer$" --nsTo="$customer$.$prefix$"
 
 .. _mongorestore-example-copy-clone-database:
 


### PR DESCRIPTION
## DESCRIPTION
Looks like mongorestore fails to copy/clone an existing database to a new one on Windows if nsfrom and nsTo values are inside single quotes; only double quotes work on windows. In my testing, double quotes work on mac too. Instead of documenting the right type of quotes to use for each OS, I replaced the quotes in the examples so it will work on mac and windows.

## STAGING
https://preview-mongodbkanchanamongodb.gatsbyjs.io/database-tools/DOCS-15555/mongodump
https://preview-mongodbkanchanamongodb.gatsbyjs.io/database-tools/DOCS-15555/mongorestore

## JIRA
https://jira.mongodb.org/browse/DOCS-15555

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65c655956b2f17c95a916fc2

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)