### PR TITLE
DOCS-11360 Clarify that mongorestore does not support concurrent restoration

### DIFF
--- a/source/mongorestore.txt
+++ b/source/mongorestore.txt
@@ -39,8 +39,10 @@ into a :binary:`~bin.mongod` or :binary:`~bin.mongos` instance.
 
 .. seealso::
 
-   :binary:`~bin.mongodump` which provides the corresponding
+   :binary:`~bin.mongodump`, which provides the corresponding
    binary data export capability.
+
+You can't run ``mongorestore`` concurrently with ``mongodump``.
 
 .. |tool-command| replace:: ``mongorestore``
 


### PR DESCRIPTION
## DESCRIPTION
Documents that mongorestore does not support concurrent restoration

## STAGING
https://preview-mongodbkanchanamongodb.gatsbyjs.io/database-tools/DOCS-11360/mongorestore/

## JIRA
https://jira.mongodb.org/browse/DOCS-11360

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65d8efc87111165982b5a6f4

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)