### PR TITLE
DOCSP-30862 Document excluded-by-default databases and collections

### DIFF
--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -302,8 +302,37 @@ value overrides the read preference specified in the URI string.
 Data Exclusion
 ~~~~~~~~~~~~~~
 
-:binary:`~bin.mongodump` excludes the content of the ``local`` database
-in its output.
+If you specify both the :option:`--db <mongodump --db>` and
+:option:`--collection <mongodump --collection>` options, ``mongodump``
+dumps everything and doesn't exclude anything in the collection except
+the following:
+
+- The ``admin.system.keys`` collection 
+- The collection that starts with ``system.`` in all databases except
+  for the collection named ``system.js``
+
+If you don't specify the :option:`--db <mongodump --db>` option,
+:binary:`~bin.mongodump` excludes the following in its output:  
+
+- The entire ``local`` database 
+- The entire ``admin`` database if you are connected to an Atlas
+  cluster. 
+
+  .. note:: ``mongodump`` returns an error if you specify the 
+   ``admin`` database as value for the ``--db`` option. 
+
+If you specify the ``config`` database as value for the ``--db`` option,
+``mongodump`` dumps everything in that database. If you don't explicitly
+specify the ``config`` database as value for the  ``--db`` option,
+``mongodump`` only includes the following collections in the output: 
+
+- ``chunks``
+- ``collections``
+- ``databases``
+- ``settings``
+- ``shards``
+- ``tags``
+- ``version``
 
 :binary:`~bin.mongodump` output:
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -302,35 +302,33 @@ value overrides the read preference specified in the URI string.
 Data Exclusion
 ~~~~~~~~~~~~~~
 
-If you specify both the :option:`--db <mongodump --db>` without the
-:option:`--collection <mongodump --collection>` option, ``mongodump``
-dumps everything in that database except the following:
+If you specify both the :option:`--db <mongodump --db>` and the
+:option:`--collection <mongodump --collection>` options, ``mongodump``
+dumps the specified collection.
 
-- The ``admin.system.keys`` collection when dumping the ``admin`` database
-- For all databases besides ``admin`` and ``config``, collections that start with ``system.``, except for ``system.js``
+If you only specify the :option:`--db <mongodump --db>` option,
+``mongodump`` dumps that database with the following exclusions:
 
-If you don't specify the :option:`--db <mongodump --db>` option,
-:binary:`~bin.mongodump` excludes the following in its output:  
+- If the value of ``--db`` is ``admin``, ``mongodump`` excludes the
+  ``system.keys`` collection. 
+- If the value of ``--db`` is ``config``, ``mongodump`` dumps all
+  collections in that database. 
+  
+  If you don't explicitly specify the ``config`` database as the value
+  for the  ``--db`` option or if you omit the ``--db`` option,
+  ``mongodump`` only includes the following collections in the output
+  for the ``config`` database: 
 
-- The entire ``local`` database 
-- The entire ``admin`` database if you are connected to an Atlas
-  cluster. 
-
-  .. note:: ``mongodump`` returns an error if you specify the 
-   ``admin`` database as the value for the ``--db`` option. 
-
-If you specify the ``config`` database as the value for the ``--db`` option,
-``mongodump`` dumps everything in that database. If you don't explicitly
-specify the ``config`` database as the value for the  ``--db`` option,
-``mongodump`` only includes the following collections in the output: 
-
-- ``chunks``
-- ``collections``
-- ``databases``
-- ``settings``
-- ``shards``
-- ``tags``
-- ``version``
+  - ``chunks``
+  - ``collections``
+  - ``databases``
+  - ``settings``
+  - ``shards``
+  - ``tags``
+  - ``version``
+  
+- For all other databases, ``mongodump`` excludes all collections that
+  start with ``system.``, except for ``system.js``. 
 
 :binary:`~bin.mongodump` output:
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -309,23 +309,30 @@ dumps the specified collection.
 If you only specify the :option:`--db <mongodump --db>` option,
 ``mongodump`` dumps that database with the following exclusions:
 
-- If the value of ``--db`` is ``admin``, ``mongodump`` excludes the
-  ``system.keys`` collection. 
+- If the value of ``--db`` is ``admin``:
+  - If you aren't connected to an Atlas Proxy, ``mongodump`` dumps the database but 
+    excludes the ``system.keys`` collection. 
+  - If you're connected to an Atlas Proxy, ``mongodump`` attempts to dump the database 
+    but errors out.
 - If the value of ``--db`` is ``config``, ``mongodump`` dumps all
   collections in that database. 
+  - If the value of ``--db`` is ``local``, ``mongodump`` dumps all collections in that database. 
   
-  If you don't explicitly specify the ``config`` database as the value
-  for the  ``--db`` option or if you omit the ``--db`` option,
-  ``mongodump`` only includes the following collections in the output
-  for the ``config`` database: 
+  If you omit the ``--db`` option:
+  - ``mongodump`` excludes the ``local`` database.
+  - ``mongodump`` only includes the following collections in the output
+    for the ``config`` database: 
 
-  - ``chunks``
-  - ``collections``
-  - ``databases``
-  - ``settings``
-  - ``shards``
-  - ``tags``
-  - ``version``
+    - ``chunks``
+    - ``collections``
+    - ``databases``
+    - ``settings``
+    - ``shards``
+    - ``tags``
+    - ``version``
+    
+  - If you're connected to an Atlas Proxy, ``mongodump`` excludes the ``admin`` 
+    database.
   
 - For all other databases, ``mongodump`` excludes all collections that
   start with ``system.``, except for ``system.js``. 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -310,32 +310,37 @@ If you only specify the :option:`--db <mongodump --db>` option,
 ``mongodump`` dumps that database with the following exclusions:
 
 - If the value of ``--db`` is ``admin``:
-  - If you aren't connected to an Atlas Proxy, ``mongodump`` dumps the database but 
-    excludes the ``system.keys`` collection. 
-  - If you're connected to an Atlas Proxy, ``mongodump`` attempts to dump the database 
-    but errors out.
+
+  - If you aren't connected to an Atlas Proxy, ``mongodump`` dumps the
+    database but excludes the ``system.keys`` collection. 
+  - If you're connected to an Atlas Proxy, ``mongodump`` attempts to
+    dump the database but errors out.
+
 - If the value of ``--db`` is ``config``, ``mongodump`` dumps all
   collections in that database. 
-  - If the value of ``--db`` is ``local``, ``mongodump`` dumps all collections in that database. 
-  
-  If you omit the ``--db`` option:
-  - ``mongodump`` excludes the ``local`` database.
-  - ``mongodump`` only includes the following collections in the output
-    for the ``config`` database: 
 
-    - ``chunks``
-    - ``collections``
-    - ``databases``
-    - ``settings``
-    - ``shards``
-    - ``tags``
-    - ``version``
-    
-  - If you're connected to an Atlas Proxy, ``mongodump`` excludes the ``admin`` 
-    database.
+- If the value of ``--db`` is ``local``, ``mongodump`` dumps all
+  collections in that database.  
   
 - For all other databases, ``mongodump`` excludes all collections that
   start with ``system.``, except for ``system.js``. 
+
+If you omit the ``--db`` option, the following exclusions apply: 
+
+- ``mongodump`` excludes the ``local`` database.
+- ``mongodump`` only includes the following collections in the output
+  for the ``config`` database:   
+
+  - ``chunks``
+  - ``collections``
+  - ``databases``
+  - ``settings``
+  - ``shards``
+  - ``tags``
+  - ``version``
+    
+- If you're connected to an Atlas Proxy, ``mongodump`` excludes the
+  ``admin`` database. 
 
 :binary:`~bin.mongodump` output:
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -302,14 +302,12 @@ value overrides the read preference specified in the URI string.
 Data Exclusion
 ~~~~~~~~~~~~~~
 
-If you specify both the :option:`--db <mongodump --db>` and
-:option:`--collection <mongodump --collection>` options, ``mongodump``
-dumps everything and doesn't exclude anything in the collection except
-the following:
+If you specify both the :option:`--db <mongodump --db>` without the
+:option:`--collection <mongodump --collection>` option, ``mongodump``
+dumps everything in that database except the following:
 
-- The ``admin.system.keys`` collection 
-- The collection that starts with ``system.`` in all databases except
-  for the collection named ``system.js``
+- The ``admin.system.keys`` collection when dumping the ``admin`` database
+- For all databases besides ``admin`` and ``config``, collections that start with ``system.``, except for ``system.js``
 
 If you don't specify the :option:`--db <mongodump --db>` option,
 :binary:`~bin.mongodump` excludes the following in its output:  
@@ -319,11 +317,11 @@ If you don't specify the :option:`--db <mongodump --db>` option,
   cluster. 
 
   .. note:: ``mongodump`` returns an error if you specify the 
-   ``admin`` database as value for the ``--db`` option. 
+   ``admin`` database as the value for the ``--db`` option. 
 
-If you specify the ``config`` database as value for the ``--db`` option,
+If you specify the ``config`` database as the value for the ``--db`` option,
 ``mongodump`` dumps everything in that database. If you don't explicitly
-specify the ``config`` database as value for the  ``--db`` option,
+specify the ``config`` database as the value for the  ``--db`` option,
 ``mongodump`` only includes the following collections in the output: 
 
 - ``chunks``


### PR DESCRIPTION
## DESCRIPTION
Upates current mongodump data exclusion behavior.

## STAGING
https://preview-mongodbkanchanamongodb.gatsbyjs.io/database-tools/DOCSP-30862/mongodump/#data-exclusion

## JIRA
https://jira.mongodb.org/browse/DOCSP-30862

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65e8aa4311db7b0427206d82

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)