### PR TITLE
DOCSP-27801-mongoimport-drop-indexes-clarification

### DIFF
--- a/source/mongoimport.txt
+++ b/source/mongoimport.txt
@@ -521,7 +521,8 @@ Options
 .. option:: --drop
 
    Modifies the import process so that the target instance drops
-   the collection before importing the data from the input.
+   the collection and any associated indexes before importing 
+   data from the input.
    
 
 

--- a/source/mongoimport.txt
+++ b/source/mongoimport.txt
@@ -521,8 +521,8 @@ Options
 .. option:: --drop
 
    Modifies the import process so that the target instance drops
-   the collection and any associated :term:`index` before importing 
-   data from the input.
+   the collection and any associated :term:`indexes <index>` before 
+   importing data from the input.
    
 
 

--- a/source/mongoimport.txt
+++ b/source/mongoimport.txt
@@ -521,7 +521,7 @@ Options
 .. option:: --drop
 
    Modifies the import process so that the target instance drops
-   the collection and any associated indexes before importing 
+   the collection and any associated :term:`index` before importing 
    data from the input.
    
 


### PR DESCRIPTION
## DESCRIPTION
Responded to user feedback by clarifying associated indexes are also removed after I verified with dev team on #mongo-tools slack channel. Slight editorial tweak as well.

## STAGING
https://preview-mongodbmmavillemdb.gatsbyjs.io/database-tools/DOCSP-27801-mongoimport-drop-indexes-clarification/mongoimport/#std-option-mongoimport.--drop

## JIRA
https://jira.mongodb.org/browse/DOCSP-2780

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65ea36456fc5f0485068de69

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)