### PR TITLE
DOCSP-38145 mongoimport default db

### DIFF
--- a/source/includes/fact-default-no-db-or-uri.rst
+++ b/source/includes/fact-default-no-db-or-uri.rst
@@ -1,3 +1,3 @@
-If you don't specify a database with the :option:`--db <mongodump --db>` or 
+If you don't specify a database with the :option:`--db <mongoimport --db>` or 
 :option:`--uri <mongoimport --uri>` option, ``mongoimport`` uses the 
 ``test`` database by default.

--- a/source/includes/fact-default-no-db-or-uri.rst
+++ b/source/includes/fact-default-no-db-or-uri.rst
@@ -1,0 +1,3 @@
+If you don't specify a database with the :option:`--db <mongodump --db>` or 
+:option:`--uri <mongoimport --uri>` option, ``mongoimport`` uses the 
+``test`` database by default.

--- a/source/includes/fact-default-no-db-or-uri.rst
+++ b/source/includes/fact-default-no-db-or-uri.rst
@@ -1,3 +1,4 @@
 If you don't specify a database with the :option:`--db <mongoimport --db>` or 
 :option:`--uri <mongoimport --uri>` option, ``mongoimport`` uses the 
-``test`` database by default.
+``test`` database by default. If the ``test`` database doesn't exist, 
+``mongoimport`` creates the database.

--- a/source/mongoimport.txt
+++ b/source/mongoimport.txt
@@ -214,7 +214,11 @@ Options
    .. code-block:: none
    
       --uri "mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]"
-   
+
+   .. note:: 
+
+      .. include:: /includes/fact-default-no-db-or-uri.rst
+
    .. include:: /includes/extracts/uri-positional-mongoimport.rst
 
    For information on the components of the connection string, see
@@ -451,6 +455,9 @@ Options
    
    .. include:: /includes/extracts/uri-used-with-db.rst
 
+   .. note:: 
+
+      .. include:: /includes/fact-default-no-db-or-uri.rst
 
 .. option:: --collection=<collection>, -c=<collection>
 


### PR DESCRIPTION
## DESCRIPTION
Adds note about `mongoimport` using the `test` database by default if a db isn't specified w/ the `--db` or `--uri` option.

## STAGING
- [`--db`](https://preview-mongodbajhuhmdb.gatsbyjs.io/database-tools/DOCSP-38145-mongoimport-default-db/mongoimport/#std-option-mongoimport.--db)
- [`--uri`](https://preview-mongodbajhuhmdb.gatsbyjs.io/database-tools/DOCSP-38145-mongoimport-default-db/mongoimport/#std-option-mongoimport.--uri)

## JIRA
https://jira.mongodb.org/browse/DOCSP-38145

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=660acb6c3a5920a291eb24e9

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)