### PR TITLE
DOCSP-38268 Add Piping Guidance to Examples

### DIFF
--- a/source/includes/extracts-clone-copy-db-examples.yaml
+++ b/source/includes/extracts-clone-copy-db-examples.yaml
@@ -27,11 +27,4 @@ content: |
       the uri or host, username, password and authentication
       database.
 
-   Alternatively, instead of using an archive file, you can
-   :binary:`~bin.mongodump` the ``test`` database to the standard
-   output stream and pipe into :binary:`~bin.mongorestore`:
-
-   .. code-block:: sh
-
-      mongodump --archive --db=test | mongorestore --archive  --nsFrom="test.*" --nsTo="examples.*"  
 ...

--- a/source/mongodump/mongodump-examples.txt
+++ b/source/mongodump/mongodump-examples.txt
@@ -140,10 +140,10 @@ As an alternative, users can use ``mongodump`` and
 
    Piping ``mongodump`` output directly into ``mongorestore`` is subject 
    to the data buffers of the read/write operations. This means for 
-   larger scale dumps, or dump operations directly from MongoDB Atlas 
+   larger scale dumps, or dump operations directly from MongoDB Atlas, 
    piping the dump data into restore in a single command can fail. For 
-   best results on large dumps, consider dumping data to a file and 
-   then using restore in separate commands.
+   best results on large dumps, consider using ``mongodump`` to dump 
+   data to a file and then using ``mongorestore`` in separate commands.
 
 .. _mongodump-example-connect-using-aws-iam:
 

--- a/source/mongodump/mongodump-examples.txt
+++ b/source/mongodump/mongodump-examples.txt
@@ -136,6 +136,15 @@ As an alternative, users can use ``mongodump`` and
 
 .. include:: /includes/extracts/clone-copy-db-same-instance.rst
 
+.. warning::
+
+   Piping ``mongodump`` output directly into ``mongorestore`` is subject 
+   to the data buffers of the read/write operations. This means for 
+   larger scale dumps, or dump operations directly from MongoDB Atlas 
+   piping the dump data into restore in a single command can fail. For 
+   best results on large dumps, consider dumping data to a file and 
+   then using restore in separate commands for best results.   
+
 .. _mongodump-example-connect-using-aws-iam:
 
 Connect to a MongoDB Atlas Cluster using AWS IAM Credentials

--- a/source/mongodump/mongodump-examples.txt
+++ b/source/mongodump/mongodump-examples.txt
@@ -143,7 +143,7 @@ As an alternative, users can use ``mongodump`` and
    larger scale dumps, or dump operations directly from MongoDB Atlas 
    piping the dump data into restore in a single command can fail. For 
    best results on large dumps, consider dumping data to a file and 
-   then using restore in separate commands for best results.   
+   then using restore in separate commands.
 
 .. _mongodump-example-connect-using-aws-iam:
 

--- a/source/mongodump/mongodump-examples.txt
+++ b/source/mongodump/mongodump-examples.txt
@@ -141,9 +141,10 @@ As an alternative, users can use ``mongodump`` and
    Piping ``mongodump`` output directly into ``mongorestore`` is subject 
    to the data buffers of the read/write operations. This means for 
    larger scale dumps, or dump operations directly from MongoDB Atlas, 
-   piping the dump data into restore in a single command can fail. For 
-   best results on large dumps, consider using ``mongodump`` to dump 
-   data to a file and then using ``mongorestore`` in separate commands.
+   piping the dump data into ``mongorestore`` in a single command can 
+   fail. For best results on large dumps, consider using ``mongodump`` 
+   to dump data to a file and then using ``mongorestore`` in separate 
+   commands.
 
 .. _mongodump-example-connect-using-aws-iam:
 

--- a/source/mongodump/mongodump-examples.txt
+++ b/source/mongodump/mongodump-examples.txt
@@ -136,16 +136,6 @@ As an alternative, users can use ``mongodump`` and
 
 .. include:: /includes/extracts/clone-copy-db-same-instance.rst
 
-.. warning::
-
-   Piping ``mongodump`` output directly into ``mongorestore`` is subject 
-   to the data buffers of the read/write operations. This means for 
-   larger scale dumps, or dump operations directly from MongoDB Atlas, 
-   piping the dump data into ``mongorestore`` in a single command can 
-   fail. For best results on large dumps, consider using ``mongodump`` 
-   to dump data to a file and then using ``mongorestore`` in separate 
-   commands.
-
 .. _mongodump-example-connect-using-aws-iam:
 
 Connect to a MongoDB Atlas Cluster using AWS IAM Credentials


### PR DESCRIPTION
## DESCRIPTION

Removing the pipe command in mongodump / restore example with the `|` operator. 
## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/database-tools/DOCSP-38268/mongodump/mongodump-examples/#copy-and-clone-database

## JIRA

https://jira.mongodb.org/browse/DOCSP-38268


## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=660dba573a5920a291c79a66

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)