### PR TITLE
DOCSP-38268 Remove Additional Piping Example

### DIFF
--- a/source/mongodump/mongodump-examples.txt
+++ b/source/mongodump/mongodump-examples.txt
@@ -79,24 +79,6 @@ of the ``test`` database.
 
    mongodump --archive=test.20150715.archive --db=test
 
-.. _mongodump-example-archive-stdout:
-
-Output an Archive to Standard Output
-------------------------------------
-
-To output the archive to the standard output stream in order to pipe to
-another process, run ``mongodump`` with the ``archive``
-option but *omit* the filename:
-
-.. code-block:: sh
-
-   mongodump --archive --db=test --port=27017 | mongorestore --archive --port=27018
-
-.. note::
-
-   You cannot use the ``--archive`` option with the
-   :option:`--out <mongodump --out>` option.
-
 .. _mongodump-example-gzip:
 
 Compress the Output


### PR DESCRIPTION
## DESCRIPTION

Removes additional piping example from the mongodump docs.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/database-tools/DOCSP-38268-b/mongodump/mongodump-examples/#output-an-archive-to-standard-output

## JIRA

https://jira.mongodb.org/browse/DOCSP-38268

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=661d151c3a5920a291481a60

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)