### PR TITLE
DOCSP-39421-detailed-extras

### DIFF
--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -60,14 +60,11 @@ Run ``mongodump`` from the system command line, not the
 
 .. include:: /includes/fact-online-archive-callout.rst
 
-``mongodump`` exports:
+``mongodump`` can export:
 
-- Collection data
-- Collection options
+- Collection documents, metadata, and options
 - Index definitions
-
-Optionally, ``mongodump`` can export writes that occur while the export
-is ongoing.
+- Writes that occur during the export
 
 ``mongodump`` exports data to a directory or an archive.
 
@@ -76,18 +73,18 @@ Export Data to a Directory
 
 For a directory export:
 
-- ``mongodump`` has a root directory where the exported files are stored
-  in subdirectories. By default, the root directory is named ``dump``
-  and is created in the directory where you run ``mongodump``, but you
-  can set the name with the ``mongodump`` :option:`--out <mongodump
-  --out>` option.
+- ``mongodump`` stores the exported files in a root directory that
+  contains subdirectories. By default, the root directory is named
+  ``dump`` and is created in the directory where you run ``mongodump``,
+  but you can set the root directory name with the ``mongodump``
+  :option:`--out <mongodump --out>` option.
 - ``mongodump`` creates a subdirectory in the root directory for each
   database.
 - Each database directory contains a ``.metadata.json`` file for each
-  collection. For example, if the collection is ``sales``, the file is
-  ``sales.metadata.json`. The BSON file is an Extended JSON (v2) format
-  file, and contains a document with the exported collection options and
-  indexes.
+  collection. For example, if a collection is named ``sales``, the
+  metadata file is ``sales.metadata.json`. The BSON file is an Extended
+  JSON v2 formatted file, and contains a document with the exported
+  collection metadata, options, and indexes.
 - Each collection also has a corresponding BSON file with the collection
   documents.
 - A view only has a ``.metadata.json`` file and doesn't have a BSON

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -78,14 +78,14 @@ For a directory export, ``mongodump`` creates:
   set the root directory name with the ``mongodump`` :option:`--out
   <mongodump --out>` option.
 - A subdirectory in the root directory for each database.
-- A ``metadata.json`` file for each collection in each database
-  directory. For example, if a collection name is ``sales``, the
-  metadata file is ``sales.metadata.json``. The file is an extended
-  JSON v2 formatted file, and contains a document with the exported
-  collection metadata, options, and indexes.
-- A corresponding BSON file with the collection documents for each
-  collection.
-- A ``metadata.json`` file for each view. A view doesn't have a BSON
+- A BSON file with documents for each collection. For example, if a
+  collection name is ``sales``, the BSON file is ``sales.bson``.
+- A metadata JSON file for each collection in each database directory.
+  For example, a metadata ``sales.metadata.json`` file. The file
+  contains a document with the exported collection metadata, options,
+  and indexes.
+- A metadata JSON file for each view. For example, a metadata
+  ``salesByMonthView.metadata.json`` file. A view doesn't have a BSON
   file.
 - An optional :term:`oplog` ``oplog.bson`` file, located in the root
   directory, which contains write operations that occurred during the
@@ -96,19 +96,20 @@ Example directory export structure and files:
 .. code-block:: none
 
    dump
-   ├── database1
-   │    ├── collection1.bson
-   │    ├── collection2.metadata.json
-   │    └── view1.metadata.json 
-   ├── database2
-   │    ├── collection1.bson
-   │    ├── collection2.metadata.json
-   │    └── view1.metadata.json
+   ├── easternSalesDatabase
+   │    ├── sales.bson
+   │    ├── sales.metadata.json
+   │    └── salesByMonthView.metadata.json 
+   ├── westernSalesDatabase
+   │    ├── sales.bson
+   │    ├── sales.metadata.json
+   │    └── salesByMonthView.metadata.json
    └── oplog.bson
 
 If you use the ``mongodump`` :option:`--gzip <mongodump --gzip>` option,
-the BSON files and JSON metadata files are compressed. The exported
-files have ``bson.gz`` and ``metadata.json.gz`` at the end of the names.
+the BSON files and JSON metadata files are compressed. The compressed
+exported files have ``bson.gz`` and ``metadata.json.gz`` at the end of
+the names.
 
 Export Data to an Archive File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -76,32 +76,36 @@ Export Data to a Directory
 
 For a directory export:
 
-- ``mongodump`` has a root directory where the exported data is stored.
-  By default, the root directory is called ``dump`` but you can set the
-  name using the ``mongodump`` :option:`--out <mongodump --out>`
-  option.
-- ``mongodump`` creates one subdirectory in the root directory for each
+- ``mongodump`` has a root directory where the exported files are stored
+  in subdirectories. By default, the root directory is named ``dump``
+  and is created in the directory where you run ``mongodump``, but you
+  can set the name with the ``mongodump`` :option:`--out <mongodump
+  --out>` option.
+- ``mongodump`` creates a subdirectory in the root directory for each
   database.
-- Each database directory ``mongodump`` creates a .metadata.json file for
-  each collection. If the collection is called ``sales``, the file will
-  be ``sales.metadata.json`. The file has an Extended JSON (v2) document
-  with details for the collection options and indexes.
-- Collections also have a BSON file containing all the
-  documents stored by the collection.
-- A view only has a .metadata.json file and doesn't have a BSON file.
+- Each database directory contains a ``.metadata.json`` file for each
+  collection. For example, if the collection is ``sales``, the file is
+  ``sales.metadata.json`. The BSON file is an Extended JSON (v2) format
+  file, and contains a document with the exported collection options and
+  indexes.
+- Each collection also has a corresponding BSON file with the collection
+  documents.
+- A view only has a ``.metadata.json`` file and doesn't have a BSON
+  file.
+- op log file XXX
 
-Example directory export structure:
+Example directory export structure and files:
 
 .. code-block:: none
 
    dump
-   ├── db1
-   │    ├── coll1.bson
-   │    ├── coll1.metadata.json
+   ├── database1
+   │    ├── collection1.bson
+   │    ├── collection2.metadata.json
    │    └── view1.metadata.json 
-   ├── db2
-   │    ├── coll1.bson
-   │    ├── coll1.metadata.json
+   ├── database2
+   │    ├── collection1.bson
+   │    ├── collection2.metadata.json
    │    └── view1.metadata.json
    └── oplog.bson
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -116,7 +116,7 @@ Export Data to a Binary Archive File
 
 To export data to a binary archive file, use the ``mongodump``
 :option:`--archive <mongodump --archive>` option. ``mongodump`` creates
-a custom MongoDB formatted binary file that contains the archived data.
+a binary file that contains the archived data.
 
 Syntax
 ------

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -60,14 +60,14 @@ Run ``mongodump`` from the system command line, not the
 
 .. include:: /includes/fact-online-archive-callout.rst
 
-``mongodump`` exports:
+``mongodump`` dumps:
 
 - Collection documents, metadata, and options.
 - Index definitions.
 - Writes that occur during the export, if run with the ``mongodump``
   :option:`--oplog <mongodump --oplog>` option.
 
-``mongodump`` exports data to a directory or a binary archive file.
+``mongodump`` dumps data to a directory or a binary archive file.
 
 Export Data to a Directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -71,7 +71,7 @@ Run ``mongodump`` from the system command line, not the
 Export Data to a Directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Example directory export structure and files:
+Example ``mongodump`` directory export structure and files:
 
 .. code-block:: none
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -104,7 +104,8 @@ For a directory export, ``mongodump`` creates:
   file.
 - An optional :term:`oplog` ``oplog.bson`` file, located in the root
   directory, which contains write operations that occurred during the
-  ``mongodump`` run.
+  ``mongodump`` run. To output an ``oplog.bson`` file, use the
+  ``mongodump`` :option:`--oplog <mongodump --oplog>` option.
 
 If you use the ``mongodump`` :option:`--gzip <mongodump --gzip>` option,
 the BSON files and JSON metadata files are compressed. The compressed

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -60,11 +60,12 @@ Run ``mongodump`` from the system command line, not the
 
 .. include:: /includes/fact-online-archive-callout.rst
 
-``mongodump`` can export:
+``mongodump`` exports:
 
 - Collection documents, metadata, and options.
 - Index definitions.
-- Writes that occur during the export.
+- Writes that occur during the export, if run with the ``mongodump``
+  :option:`--oplog <mongodump --oplog>` option.
 
 ``mongodump`` exports data to a directory or a binary archive file.
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -60,6 +60,63 @@ Run ``mongodump`` from the system command line, not the
 
 .. include:: /includes/fact-online-archive-callout.rst
 
+``mongodump`` exports data from collections, along with collection
+options and index definitions. Optionally, ``mongodump`` can export
+writes that occur while the export is ongoing.
+
+``mongodump`` exports data to a directory or an archive.
+
+Directory Export
+~~~~~~~~~~~~~~~~
+
+For a directory export:
+
+- ``mongodump`` has a root directory where the exported data is
+  stored. By default, the root directory is called ``dump`` but you can set
+  the name using the ``--out`` option.
+- ``mongodump`` creates one subdirectory in the root directory for each
+  database.
+- Inside each database directory mongodump creates a .metadata.json file
+  for each collection. If the collection is called foo, the file will be
+  foo.metadata.json. This file contains an Extended JSON (v2) document
+  which describes the options and indexes of the collection.
+- Regular collections will also have a BSON file containing all the
+  documents dumped for the collection.
+- A view will only have a .metadata.json file and will not have a BSON
+  file.
+
+Example directory dump structure:
+
+.. code-block:: none
+
+   dump
+   ├── db1
+   │    ├── coll1.bson
+   │    ├── coll1.metadata.json
+   │    └── view1.metadata.json 
+   ├── db2
+   │    ├── coll1.bson
+   │    ├── coll1.metadata.json
+   │    └── view1.metadata.json
+   └── oplog.bson
+
+If the dump was created with the --gzip option, then the bson files and
+the .metadata.json files will be gzipped. Their extensions will be
+.bson.gz and .metadata.json.gz.
+
+Archive Export
+~~~~~~~~~~~~~~
+
+For an archive export:
+
+Archive dumps are binary files in a custom MongoDB format. It is
+possible to edit archives. However, editing archives is prone to error
+and you could accidentally corrupt your archive. We recommend reaching
+out to MongoDB Support if you need to edit your archive file.
+
+:option:`--out=<path>, -o=<path>`
+:option:`--archive=<file>`
+
 Syntax
 ------
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -88,10 +88,8 @@ Example ``mongodump`` directory export structure and files:
 
 For a directory export, ``mongodump`` creates:
 
-- A root directory. By default, the root directory is named ``dump`` and
-  is created in the directory where you run ``mongodump``, but you can
-  set the root directory name with the ``mongodump`` :option:`--out
-  <mongodump --out>` option.
+- A root directory with the default name ``dump``. You can set the name
+  with the ``mongodump`` :option:`--out <mongodump --out>` option.
 - A subdirectory in the root directory for each database. For example,
   if a database name is ``easternSalesDatabase``, the subdirectory name
   is also ``easternSalesDatabase``.

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -79,8 +79,8 @@ For a directory export, ``mongodump`` creates:
   <mongodump --out>` option.
 - A subdirectory in the root directory for each database.
 - A ``.metadata.json`` file for each collection in each database
-  directory. For example, if a collection is named ``sales``, the
-  metadata file is ``sales.metadata.json`. The BSON file is an Extended
+  directory. For example, if a collection name is ``sales``, the
+  metadata file is ``sales.metadata.json`. The file is an extended
   JSON v2 formatted file, and contains a document with the exported
   collection metadata, options, and indexes.
 - A corresponding BSON file with the collection documents for each
@@ -88,7 +88,7 @@ For a directory export, ``mongodump`` creates:
 - A ``.metadata.json`` file for each view. A view doesn't have a BSON
   file.
 - An optional :term:`oplog` ``oplog.bson`` file, located in the root
-  directory, which contains write operations that occur during the
+  directory, which contains write operations that occurred during the
   ``mongodump`` run.
 
 Example directory export structure and files:
@@ -107,9 +107,8 @@ Example directory export structure and files:
    └── oplog.bson
 
 If you use the ``mongodump`` :option:`--gzip <mongodump --gzip>` option,
-the BSON files and ``.metadata.json`` files are compressed using
-``gzip``. The exported file extensions are ``.bson.gz`` and
-``.metadata.json.gz``.
+the BSON files and JSON metadata files are compressed using ``gzip``.
+The exported file extensions are ``.bson.gz`` and ``.metadata.json.gz``.
 
 Export Data to an Archive File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -62,34 +62,14 @@ Run ``mongodump`` from the system command line, not the
 
 ``mongodump`` can export:
 
-- Collection documents, metadata, and options
-- Index definitions
-- Writes that occur during the export
+- Collection documents, metadata, and options.
+- Index definitions.
+- Writes that occur during the export.
 
-``mongodump`` exports data to a directory or an archive.
+``mongodump`` exports data to a directory or a binary archive file.
 
 Export Data to a Directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For a directory export, ``mongodump`` creates:
-
-- A root directory. By default, the root directory is named ``dump`` and
-  is created in the directory where you run ``mongodump``, but you can
-  set the root directory name with the ``mongodump`` :option:`--out
-  <mongodump --out>` option.
-- A subdirectory in the root directory for each database.
-- A BSON file with documents for each collection. For example, if a
-  collection name is ``sales``, the BSON file is ``sales.bson``.
-- A metadata JSON file for each collection in each database directory.
-  For example, a metadata ``sales.metadata.json`` file. The file
-  contains a document with the exported collection metadata, options,
-  and indexes.
-- A metadata JSON file for each view. For example, a metadata
-  ``salesByMonthView.metadata.json`` file. A view doesn't have a BSON
-  file.
-- An optional :term:`oplog` ``oplog.bson`` file, located in the root
-  directory, which contains write operations that occurred during the
-  ``mongodump`` run.
 
 Example directory export structure and files:
 
@@ -106,17 +86,39 @@ Example directory export structure and files:
    │    └── salesByMonthView.metadata.json
    └── oplog.bson
 
+For a directory export, ``mongodump`` creates:
+
+- A root directory. By default, the root directory is named ``dump`` and
+  is created in the directory where you run ``mongodump``, but you can
+  set the root directory name with the ``mongodump`` :option:`--out
+  <mongodump --out>` option.
+- A subdirectory in the root directory for each database. For example,
+  if a database name is ``easternSalesDatabase``, the subdirectory name
+  is also ``easternSalesDatabase``.
+- A BSON file with documents for each collection. For example, if a
+  collection name is ``sales``, the BSON file is ``sales.bson``.
+- A metadata JSON file for each collection in each database directory.
+  For example, a metadata ``sales.metadata.json`` file. The file
+  contains a document with the exported collection metadata, options,
+  and indexes.
+- A metadata JSON file for each view. For example, a metadata
+  ``salesByMonthView.metadata.json`` file. A view doesn't have a BSON
+  file.
+- An optional :term:`oplog` ``oplog.bson`` file, located in the root
+  directory, which contains write operations that occurred during the
+  ``mongodump`` run.
+
 If you use the ``mongodump`` :option:`--gzip <mongodump --gzip>` option,
 the BSON files and JSON metadata files are compressed. The compressed
 exported files have ``bson.gz`` and ``metadata.json.gz`` at the end of
 the names.
 
-Export Data to an Archive File
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Export Data to a Binary Archive File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To export data to an archive file, use the ``mongodump``
+To export data to a binary archive file, use the ``mongodump``
 :option:`--archive <mongodump --archive>` option. ``mongodump`` creates
-a custom MongoDB format binary file. 
+a custom MongoDB formatted binary file that contains the archived data.
 
 Syntax
 ------

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -80,7 +80,7 @@ For a directory export, ``mongodump`` creates:
 - A subdirectory in the root directory for each database.
 - A ``.metadata.json`` file for each collection in each database
   directory. For example, if a collection name is ``sales``, the
-  metadata file is ``sales.metadata.json`. The file is an extended
+  metadata file is ``sales.metadata.json``. The file is an extended
   JSON v2 formatted file, and contains a document with the exported
   collection metadata, options, and indexes.
 - A corresponding BSON file with the collection documents for each

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -107,9 +107,8 @@ Example directory export structure and files:
    └── oplog.bson
 
 If you use the ``mongodump`` :option:`--gzip <mongodump --gzip>` option,
-the BSON files and JSON metadata files are compressed using ``gzip``.
-The exported files have ``bson.gz`` and ``metadata.json.gz`` at the end
-of the names.
+the BSON files and JSON metadata files are compressed. The exported
+files have ``bson.gz`` and ``metadata.json.gz`` at the end of the names.
 
 Export Data to an Archive File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -114,8 +114,8 @@ possible to edit archives. However, editing archives is prone to error
 and you could accidentally corrupt your archive. We recommend reaching
 out to MongoDB Support if you need to edit your archive file.
 
-:option:`--out=<path>, -o=<path>`
-:option:`--archive=<file>`
+:option:`--out <mongodump --out>`
+:option:`--archive <mongodump --archive>`
 
 Syntax
 ------

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -66,26 +66,26 @@ writes that occur while the export is ongoing.
 
 ``mongodump`` exports data to a directory or an archive.
 
-Directory Export
-~~~~~~~~~~~~~~~~
+Export Data to a Directory
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For a directory export:
 
-- ``mongodump`` has a root directory where the exported data is
-  stored. By default, the root directory is called ``dump`` but you can set
-  the name using the ``--out`` option.
+- ``mongodump`` has a root directory where the exported data is stored.
+  By default, the root directory is called ``dump`` but you can set the
+  name using the ``mongodump`` :option:`--out <mongodump --out>`
+  option.
 - ``mongodump`` creates one subdirectory in the root directory for each
   database.
-- Inside each database directory mongodump creates a .metadata.json file
-  for each collection. If the collection is called foo, the file will be
-  foo.metadata.json. This file contains an Extended JSON (v2) document
-  which describes the options and indexes of the collection.
-- Regular collections will also have a BSON file containing all the
-  documents dumped for the collection.
-- A view will only have a .metadata.json file and will not have a BSON
-  file.
+- Each database directory ``mongodump`` creates a .metadata.json file for
+  each collection. If the collection is called ``sales``, the file will
+  be ``sales.metadata.json`. The file has an Extended JSON (v2) document
+  with details for the collection options and indexes.
+- Collections also have a BSON file containing all the
+  documents stored by the collection.
+- A view only has a .metadata.json file and doesn't have a BSON file.
 
-Example directory dump structure:
+Example directory export structure:
 
 .. code-block:: none
 
@@ -100,22 +100,17 @@ Example directory dump structure:
    │    └── view1.metadata.json
    └── oplog.bson
 
-If the dump was created with the --gzip option, then the bson files and
-the .metadata.json files will be gzipped. Their extensions will be
-.bson.gz and .metadata.json.gz.
+If you use the ``mongodump`` :option:`--gzip <mongodump --gzip>` option,
+the BSON files and the ``.metadata.json`` files are compressed using
+``gzip``. The file extensions are ``.bson.gz`` and
+``.metadata.json.gz``.
 
-Archive Export
-~~~~~~~~~~~~~~
+Export Data to an Archive File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For an archive export:
-
-Archive dumps are binary files in a custom MongoDB format. It is
-possible to edit archives. However, editing archives is prone to error
-and you could accidentally corrupt your archive. We recommend reaching
-out to MongoDB Support if you need to edit your archive file.
-
-:option:`--out <mongodump --out>`
-:option:`--archive <mongodump --archive>`
+To export data to an archive file, use the ``mongodump``
+:option:`--archive <mongodump --archive>` option. ``mongodump`` creates
+a custom MongoDB format binary file. 
 
 Syntax
 ------

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -78,14 +78,14 @@ For a directory export, ``mongodump`` creates:
   set the root directory name with the ``mongodump`` :option:`--out
   <mongodump --out>` option.
 - A subdirectory in the root directory for each database.
-- A ``.metadata.json`` file for each collection in each database
+- A ``metadata.json`` file for each collection in each database
   directory. For example, if a collection name is ``sales``, the
   metadata file is ``sales.metadata.json``. The file is an extended
   JSON v2 formatted file, and contains a document with the exported
   collection metadata, options, and indexes.
 - A corresponding BSON file with the collection documents for each
   collection.
-- A ``.metadata.json`` file for each view. A view doesn't have a BSON
+- A ``metadata.json`` file for each view. A view doesn't have a BSON
   file.
 - An optional :term:`oplog` ``oplog.bson`` file, located in the root
   directory, which contains write operations that occurred during the
@@ -108,7 +108,8 @@ Example directory export structure and files:
 
 If you use the ``mongodump`` :option:`--gzip <mongodump --gzip>` option,
 the BSON files and JSON metadata files are compressed using ``gzip``.
-The exported file extensions are ``.bson.gz`` and ``.metadata.json.gz``.
+The exported files have ``bson.gz`` and ``metadata.json.gz`` at the end
+of the names.
 
 Export Data to an Archive File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -60,9 +60,14 @@ Run ``mongodump`` from the system command line, not the
 
 .. include:: /includes/fact-online-archive-callout.rst
 
-``mongodump`` exports data from collections, along with collection
-options and index definitions. Optionally, ``mongodump`` can export
-writes that occur while the export is ongoing.
+``mongodump`` exports:
+
+- Collection data
+- Collection options
+- Index definitions
+
+Optionally, ``mongodump`` can export writes that occur while the export
+is ongoing.
 
 ``mongodump`` exports data to a directory or an archive.
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -69,10 +69,10 @@ Run ``mongodump`` from the system command line, not the
 
 ``mongodump`` dumps data to a directory or a binary archive file.
 
-Export Data to a Directory
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Dump Data to a Directory
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-Example ``mongodump`` directory export structure and files:
+Example ``mongodump`` directory dump structure and files:
 
 .. code-block:: none
 
@@ -87,7 +87,7 @@ Example ``mongodump`` directory export structure and files:
    │    └── salesByMonthView.metadata.json
    └── oplog.bson
 
-For a directory export, ``mongodump`` creates:
+For a directory dump, ``mongodump`` creates:
 
 - A root directory with the default name ``dump``. You can set the name
   with the ``mongodump`` :option:`--out <mongodump --out>` option.
@@ -113,10 +113,10 @@ the BSON files and JSON metadata files are compressed. The compressed
 exported files have ``bson.gz`` and ``metadata.json.gz`` at the end of
 the names.
 
-Export Data to a Binary Archive File
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Dump Data to a Binary Archive File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To export data to a binary archive file, use the ``mongodump``
+To dump data to a binary archive file, use the ``mongodump``
 :option:`--archive <mongodump --archive>` option. ``mongodump`` creates
 a binary file that contains the archived data.
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -87,7 +87,7 @@ For a directory export, ``mongodump`` creates:
   collection.
 - A ``.metadata.json`` file for each view. A view doesn't have a BSON
   file.
-- CAn optional :term:`oplog` ``oplog.bson`` file, located in the root
+- An optional :term:`oplog` ``oplog.bson`` file, located in the root
   directory, which contains write operations that occur during the
   ``mongodump`` run.
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -71,25 +71,25 @@ Run ``mongodump`` from the system command line, not the
 Export Data to a Directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For a directory export:
+For a directory export, ``mongodump`` creates:
 
-- ``mongodump`` stores the exported files in a root directory that
-  contains subdirectories. By default, the root directory is named
-  ``dump`` and is created in the directory where you run ``mongodump``,
-  but you can set the root directory name with the ``mongodump``
-  :option:`--out <mongodump --out>` option.
-- ``mongodump`` creates a subdirectory in the root directory for each
-  database.
-- Each database directory contains a ``.metadata.json`` file for each
-  collection. For example, if a collection is named ``sales``, the
+- A root directory. By default, the root directory is named ``dump`` and
+  is created in the directory where you run ``mongodump``, but you can
+  set the root directory name with the ``mongodump`` :option:`--out
+  <mongodump --out>` option.
+- A subdirectory in the root directory for each database.
+- A ``.metadata.json`` file for each collection in each database
+  directory. For example, if a collection is named ``sales``, the
   metadata file is ``sales.metadata.json`. The BSON file is an Extended
   JSON v2 formatted file, and contains a document with the exported
   collection metadata, options, and indexes.
-- Each collection also has a corresponding BSON file with the collection
-  documents.
-- A view only has a ``.metadata.json`` file and doesn't have a BSON
+- A corresponding BSON file with the collection documents for each
+  collection.
+- A ``.metadata.json`` file for each view. A view doesn't have a BSON
   file.
-- op log file XXX
+- CAn optional :term:`oplog` ``oplog.bson`` file, located in the root
+  directory, which contains write operations that occur during the
+  ``mongodump`` run.
 
 Example directory export structure and files:
 
@@ -107,8 +107,8 @@ Example directory export structure and files:
    └── oplog.bson
 
 If you use the ``mongodump`` :option:`--gzip <mongodump --gzip>` option,
-the BSON files and the ``.metadata.json`` files are compressed using
-``gzip``. The file extensions are ``.bson.gz`` and
+the BSON files and ``.metadata.json`` files are compressed using
+``gzip``. The exported file extensions are ``.bson.gz`` and
 ``.metadata.json.gz``.
 
 Export Data to an Archive File


### PR DESCRIPTION
## DESCRIPTION

Added extra details for mongodump per request. 

Unfortunately, we cannot doc both mongodump and mongorestore on the same page because of how the docs platform works. Each set of options tags on a doc page must be tied to the tool tag itself ("mongodump" or "mongorestore"). We also have a docs standards requirement to try to keep pages shorter. Added other details per JIRA.

## STAGING

https://preview-mongodbjasonpricemongodb.gatsbyjs.io/database-tools/DOCSP-39421-detailed-extras/mongodump/#definition

## JIRA

https://jira.mongodb.org/browse/DOCSP-39421

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=664e64b6cf5bec1c29d25d35

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)