### PR TITLE
DOCSP-40296 Remove Debian 8 Support Documentation

### DIFF
--- a/source/includes/fact-debian8-eol.rst
+++ b/source/includes/fact-debian8-eol.rst
@@ -1,0 +1,2 @@
+Starting in version ``x.x.x`` database tools no longer supports the
+Debian 8 operating system.

--- a/source/includes/fact-debian8-eol.rst
+++ b/source/includes/fact-debian8-eol.rst
@@ -1,2 +1,2 @@
-Starting in version ``x.x.x`` database tools no longer supports the
+Starting in version ``100.9.5`` database tools no longer supports the
 Debian 8 operating system.

--- a/source/includes/fact-debian8-eol.rst
+++ b/source/includes/fact-debian8-eol.rst
@@ -1,2 +1,2 @@
-Starting in version ``100.9.5`` database tools no longer supports the
+Starting in version ``100.9.5``, database tools no longer supports the
 Debian 8 operating system.

--- a/source/includes/fact-platform-support.rst
+++ b/source/includes/fact-platform-support.rst
@@ -41,12 +41,6 @@
     -
     -
 
-  * - Debian 8
-    - 
-    -
-    -
-    -
-
   * - :abbr:`RHEL (Red Hat Enterprise Linux)` / CentOS 9
     - |checkmark|
     - |checkmark|

--- a/source/includes/fact-platform-support.rst
+++ b/source/includes/fact-platform-support.rst
@@ -42,7 +42,7 @@
     -
 
   * - Debian 8
-    - |checkmark|
+    - 
     -
     -
     -

--- a/source/installation/installation-linux.txt
+++ b/source/installation/installation-linux.txt
@@ -50,7 +50,7 @@ The {+dbtools+} version ``{+release+}`` are supported on the following
 platforms on the ``x86_64`` architecture:
 
 - Amazon Linux 2 and 2013.03+
-- Debian 10, 9, and 8
+- Debian 10 and 9
 - RHEL / CentOS 8, 7, and 6
 - SUSE 12
 - Ubuntu 20.04, 18.04, and 16.04
@@ -59,6 +59,10 @@ In addition, the {+dbtools-short+} also support select Linux platforms
 on the ``arm64``, ``ppc64le``, and ``s390x`` architectures.  See
 :ref:`Supported Platforms <dbtools-platform-support>` for more
 information.
+
+.. note::
+   
+   .. include:: /includes/fact-debian8-eol.rst
 
 Installation
 ------------


### PR DESCRIPTION
## DESCRIPTION

- Removes Debian 8 references from database tools support.
- This change will also be referenced in the ``100.9.5`` release notes as part of another PR.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/database-tools/DOCSP-40296/installation/installation-linux/#platform-support

https://preview-mongodbianfmongodb.gatsbyjs.io/database-tools/DOCSP-40296/installation/installation/#platform-support

## JIRA

https://jira.mongodb.org/browse/DOCSP-40296


## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6668700eebce19f314edce18

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)