### PR TITLE
DOCSP-39633 fixes mongostat table format

### DIFF
--- a/source/mongostat.txt
+++ b/source/mongostat.txt
@@ -617,16 +617,30 @@ average operations per second.
 
    The replication status of the member.
 
-   =========  =========================
-   **Value**  **Replication Type**
-   ---------  -------------------------
-   PRI        :term:`primary`
-   SEC        :term:`secondary`
-   REC        recovering
-   UNK        unknown
-   RTR        mongos process ("router")
-   ARB        :term:`arbiter`
-   =========  =========================
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 80
+
+      * - Value
+        - Replication Type
+
+      * - ``PRI``
+        - :term:`primary`
+
+      * - ``SEC``
+        - :term:`secondary`
+
+      * - ``REC``
+        - recovering
+
+      * - ``UNK``
+        - unknown
+
+      * - ``RTR``
+        - mongos process ("router")
+
+      * - ``ARB``
+        - :term:`arbiter`
 
 
 Additional Information

--- a/source/mongostat.txt
+++ b/source/mongostat.txt
@@ -637,7 +637,7 @@ average operations per second.
         - unknown
 
       * - ``RTR``
-        - mongos process ("router")
+        - ``mongos`` process ("router")
 
       * - ``ARB``
         - :term:`arbiter`


### PR DESCRIPTION
## DESCRIPTION
Currently, `mongostat` docs use a table that has incorrect formatting.
This PR migrates that table content to a `.. list-table::` directive

## STAGING
The updated table is just above this anchor link, in the `repl` field description.
https://preview-mongodbjwilsonmdb.gatsbyjs.io/database-tools/DOCSP-39633/mongostat/#additional-information

## JIRA
https://jira.mongodb.org/browse/DOCSP-39633

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=667b398cebce19f31413949c

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)