### PR TITLE
DOCSP-42141 Adds Debian 11/12 to title matrix

### DIFF
--- a/source/includes/fact-platform-support.rst
+++ b/source/includes/fact-platform-support.rst
@@ -19,7 +19,7 @@
 
   * - Amazon 2
     - |checkmark|
-    -
+    - |checkmark|
     -
     -
 
@@ -86,6 +86,18 @@
   * - SUSE 12
     - |checkmark|
     -
+    -
+    -
+
+  * - Ubuntu 24.04
+    - |checkmark|
+    - |checkmark|
+    -
+    -
+
+  * - Ubuntu 22.04
+    - |checkmark|
+    - |checkmark|
     -
     -
 

--- a/source/includes/fact-platform-support.rst
+++ b/source/includes/fact-platform-support.rst
@@ -29,6 +29,18 @@
     -
     -
 
+  * - Debian 12
+    - |checkmark|
+    -
+    -
+    -
+
+  * - Debian 11
+    - |checkmark|
+    -
+    -
+    -
+
   * - Debian 10
     - |checkmark|
     -


### PR DESCRIPTION
## DESCRIPTION
Adds Debian 11 and 12 to the platform support matrix.

## STAGING
[Platform Support include](https://deploy-preview-171--docs-commandline-tools.netlify.app/mongodump/mongodump-compatibility-and-installation/#platform-support)

## JIRA
[DOCSP-42141](https://jira.mongodb.org/browse/DOCSP-43141)

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)