### PR TITLE
DOCSP-43376 removing duplicate word

### DIFF
--- a/source/mongoimport.txt
+++ b/source/mongoimport.txt
@@ -413,11 +413,10 @@ Options
    Specifies the file type to import. The default format is :term:`JSON`,
    but it's possible to import :term:`CSV` and :term:`TSV` files.
    
-   The ``csv`` parser accepts that data that complies with RFC
-   :rfc:`4180`. As a result, backslashes are *not* a valid escape
-   character. If you use double-quotes to enclose fields in the CSV
-   data, you must escape internal double-quote marks by prepending
-   another double-quote.
+   The ``csv`` parser accepts that data that complies with :rfc:`4180`. 
+   As a result, backslashes are *not* a valid escape character. If you use 
+   double-quotes to enclose fields in the CSV data, you must escape internal 
+   double-quote marks by prepending another double-quote.
    
 
 


### PR DESCRIPTION
## DESCRIPTION
Quick win; removes a duplicate "RFC" from the `mongoimport` page. 

## STAGING
https://deploy-preview-173--docs-commandline-tools.netlify.app/mongoimport/

## JIRA
https://jira.mongodb.org/browse/DOCSP-43376

## BUILD LOG
See below.

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)