### PR TITLE
DOCSP-44864-redo-restore-import-if-rollback

### DIFF
--- a/source/includes/fact-target-cluster-rollbacks.rst
+++ b/source/includes/fact-target-cluster-rollbacks.rst
@@ -1,0 +1,6 @@
+.. note:: Target cluster rollbacks
+   
+   If the cluster undergoes a rollback during the restore process,
+   delete all restored or imported data and redo the process from 
+   the beginning. See :ref:`the rollback documentation<replica-set-rollbacks>` 
+   for more details.

--- a/source/mongodump/mongodump-behavior.txt
+++ b/source/mongodump/mongodump-behavior.txt
@@ -209,6 +209,14 @@ following limitations apply:
   - :option:`--dumpDbUsersAndRoles`
   - :option:`--oplog <mongodump --oplog>`
 
+.. note:: Rollback on the target cluster during a restore or import
+   
+   If you are restoring or importing data to a cluster that undergoes a
+   rollback during the restore or import process, you should delete all 
+   restored or imported data and redo the process from the beginning to
+   ensure that all data is safely restored or imported. See 
+   :ref:`the rollback documentation<replica-set-rollbacks>` for more details.
+
 Required Access
 ---------------
 

--- a/source/mongodump/mongodump-behavior.txt
+++ b/source/mongodump/mongodump-behavior.txt
@@ -211,7 +211,6 @@ following limitations apply:
 
 .. include:: /includes/fact-target-cluster-rollbacks.rst
 
-
 Required Access
 ---------------
 

--- a/source/mongodump/mongodump-behavior.txt
+++ b/source/mongodump/mongodump-behavior.txt
@@ -209,13 +209,8 @@ following limitations apply:
   - :option:`--dumpDbUsersAndRoles`
   - :option:`--oplog <mongodump --oplog>`
 
-.. note:: Rollback on the target cluster during a restore or import
-   
-   If you are restoring or importing data to a cluster that undergoes a
-   rollback during the restore or import process, you should delete all 
-   restored or imported data and redo the process from the beginning to
-   ensure that all data is safely restored or imported. See 
-   :ref:`the rollback documentation<replica-set-rollbacks>` for more details.
+.. include:: /includes/fact-target-cluster-rollbacks.rst
+
 
 Required Access
 ---------------

--- a/source/mongorestore/mongorestore-behavior-access-usage.txt
+++ b/source/mongorestore/mongorestore-behavior-access-usage.txt
@@ -114,6 +114,14 @@ following limitations apply:
   - :option:`--oplogReplay <mongorestore --oplogReplay>`
   - :option:`--preserveUUID <mongorestore --preserveUUID>`
 
+.. note:: Rollback on the target cluster during a restore or import
+   
+   If you are restoring or importing data to a cluster that undergoes a
+   rollback during the restore or import process, you should delete all 
+   restored or imported data and redo the process from the beginning to
+   ensure that all data is safely restored or imported. See 
+   :ref:`the rollback documentation<replica-set-rollbacks>` for more details.
+
 .. _mongorestore-required-access:
 
 Required Access

--- a/source/mongorestore/mongorestore-behavior-access-usage.txt
+++ b/source/mongorestore/mongorestore-behavior-access-usage.txt
@@ -114,13 +114,7 @@ following limitations apply:
   - :option:`--oplogReplay <mongorestore --oplogReplay>`
   - :option:`--preserveUUID <mongorestore --preserveUUID>`
 
-.. note:: Rollback on the target cluster during a restore or import
-   
-   If you are restoring or importing data to a cluster that undergoes a
-   rollback during the restore or import process, you should delete all 
-   restored or imported data and redo the process from the beginning to
-   ensure that all data is safely restored or imported. See 
-   :ref:`the rollback documentation<replica-set-rollbacks>` for more details.
+.. include:: /includes/fact-target-cluster-rollbacks.rst
 
 .. _mongorestore-required-access:
 


### PR DESCRIPTION
## DESCRIPTION
add a note about rollbacks in [`mongodump`](https://www.mongodb.com/docs/database-tools/mongodump/mongodump-behavior/) & [`mongorestore`](https://www.mongodb.com/docs/database-tools/mongorestore/mongorestore-behavior-access-usage/)'s behavior sections about rollback on the target cluster during a restore or import to account for the effects of [TOOLS-3696](https://jira.mongodb.org/browse/TOOLS-3696).


## STAGING
- https://deploy-preview-176--docs-commandline-tools.netlify.app/mongodump/mongodump-behavior/#using-mongodump-on-atlas-free-and-shared-tier-clusters
- https://deploy-preview-176--docs-commandline-tools.netlify.app/mongorestore/mongorestore-behavior-access-usage/#using-mongorestore-on-atlas-free-and-shared-tier-clusters


## JIRA
https://jira.mongodb.org/browse/DOCSP-44864

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)