### PR TITLE
DOCSP-45578-no-QE-support

### DIFF
--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -69,6 +69,10 @@ Run ``mongodump`` from the system command line, not the
 
 ``mongodump`` dumps data to a directory or a binary archive file.
 
+.. important:: 
+
+   You can't use ``mongodump`` with a collection that uses {+qe+}.
+
 Dump Data to a Directory
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/mongorestore.txt
+++ b/source/mongorestore.txt
@@ -50,6 +50,9 @@ Run ``mongorestore`` from the system command line, not the
 MongoDB doesn't support running multiple ``mongorestore`` programs concurrently 
 for the same collection.
 
+.. important:: 
+
+   You can't use ``mongorestore`` with a collection that uses {+qe+}.
 
 .. include:: /includes/fact-migrate-atlas.rst
 
@@ -803,8 +806,7 @@ Options
 
    Enables ``mongorestore`` to bypass :manual:`document validation </core/schema-validation>`
    during the operation. This lets you insert documents that do not
-   meet the validation requirements. This option is required if you are
-   restoring a {+qe+} enabled collection.
+   meet the validation requirements.
 
 .. _mongorestore-path-option:
 

--- a/source/mongorestore/mongorestore-examples.txt
+++ b/source/mongorestore/mongorestore-examples.txt
@@ -108,23 +108,6 @@ Alternatively, you can restore a specific collection using the
    2019-06-30T12:21:44.987-0400   finished restoring test.purchaseorders (6 documents, 0 failures)
    2019-06-30T12:21:44.987-0400   6 document(s) restored successfully. 0 document(s) failed to restore.
 
-Restore a {+qe+} Enabled Collection
-------------------------------------------------------------------------
-
-{+qe+} adds a ``__safeContent__`` field to documents in an encrypted
-collection and blocks insert and update operations on those
-documents unless document validation is disabled. To restore a
-collection that includes encrypted fields, use
-:option:`--bypassDocumentValidation <mongorestore --bypassDocumentValidation>`.
-
-:binary:`~bin.mongodump` exports a {+qe+} enabled collection's
-associated metadata collections. Running ``mongorestore`` restores these collections as well.
-
-
-.. code-block:: sh
-
-   mongorestore --db=test --collection=personaldata dump/test/personaldata.bson --bypassDocumentValidation
-
 .. _example-basic-wildcard-usage:
 
 Restore Collections Using Wild Cards


### PR DESCRIPTION
## DESCRIPTION
Note that QE isn't supported with `mongodump` and `mongorestore`
- Also remove QE `mongorestore` example

See discussion in this [Slack thread](https://mongodb.slack.com/archives/C039YP9P7G9/p1732303595603359).

## STAGING
- [mongorestore](https://deploy-preview-177--docs-commandline-tools.netlify.app/mongorestore/#mongorestore)
- [mongodump](https://deploy-preview-177--docs-commandline-tools.netlify.app/mongodump/#:~:text=binary%20archive%20file.-,IMPORTANT,-You%20can%27t%20use)

## JIRA
[DOCSP-45578](https://jira.mongodb.org/browse/DOCSP-45578)


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)