### PR TITLE
DOCSP-24948-mongorestore-nsExclude-nsInclude-precedence

### DIFF
--- a/source/includes/fact-nsExclude-precedence.rst
+++ b/source/includes/fact-nsExclude-precedence.rst
@@ -1,0 +1,5 @@
+If you specify both ``--nsExclude`` and ``--nsInclude``, the pattern 
+that ``--nsExclude`` specifies takes precedence. For example, if you
+specify both ``--nsExclude="prod.*"`` and ``--nsInclude="prod.trips"``, 
+the pattern specified by ``--nsExclude`` takes precedence and no 
+collections from the ``prod`` namespace are restored. 

--- a/source/includes/fact-nsExclude-precedence.rst
+++ b/source/includes/fact-nsExclude-precedence.rst
@@ -1,5 +1,4 @@
 If you specify both ``--nsExclude`` and ``--nsInclude``, the pattern 
 that ``--nsExclude`` specifies takes precedence. For example, if you
 specify both ``--nsExclude="prod.*"`` and ``--nsInclude="prod.trips"``, 
-the pattern specified by ``--nsExclude`` takes precedence and no 
-collections from the ``prod`` namespace are restored. 
+no collections from the ``prod`` namespace are restored. 

--- a/source/mongorestore.txt
+++ b/source/mongorestore.txt
@@ -461,6 +461,7 @@ Options
    You can specify :option:`--nsExclude` multiple times to exclude multiple namespace
    patterns.
 
+   .. include:: /includes/fact-nsExclude-precedence.rst
 
 .. option:: --nsInclude=<namespace pattern>
 
@@ -486,6 +487,7 @@ Options
    For example, if the dump directory contains
    ``dump/test/caf%C3%A9s.bson``, specify ``--nsInclude "test.cafés"``.
 
+   .. include:: /includes/fact-nsExclude-precedence.rst
 
 .. option:: --nsFrom=<namespace pattern>
 


### PR DESCRIPTION
## DESCRIPTION

Documents that ``--nsExclude`` takes precedence over ``--nsInclude`` in cases where both are specified.

**Test Results**: https://gist.github.com/jmd-mongo/63690ba41fcea86fcb8880902559b992

## STAGING

- https://deploy-preview-178--docs-commandline-tools.netlify.app/mongorestore/#std-option-mongorestore.--nsExclude
- https://deploy-preview-178--docs-commandline-tools.netlify.app/mongorestore/#std-option-mongorestore.--nsInclude

## JIRA

https://jira.mongodb.org/browse/DOCSP-24948

## Self-Review Checklist

- [X] Is this free of any warnings or errors in the RST?
- [X] Is this free of spelling errors?
- [X] Is this free of grammatical errors?
- [X] Is this free of staging / rendering issues?
- [X] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)