### PR TITLE
add note that restoreDbUsersAndRoles requires dumpDbUsersAndRoles

### DIFF
--- a/source/mongorestore.txt
+++ b/source/mongorestore.txt
@@ -725,14 +725,13 @@ Options
 
    .. note::
 
-      The :option:`--restoreDbUsersAndRoles` option cannot be used if
-      specifying the ``admin`` database to the :option:`--db
-      <mongorestore --db>` option, and attempting to do so will result
-      in an error. Restoring the ``admin`` database by specifying
-      :option:`--db admin <mongorestore --db>` to
-      ``mongorestore`` already restores all users and roles.
-   
+      - You can only use ``--restoreDbUsersAndRoles`` on a database dump that 
+        was created with the :option:`--dumpDbUsersAndRoles` option. 
 
+      - Restoring the ``admin`` database by specifying 
+        :option:`--db admin <mongorestore --db>` auotmatically restores all 
+        users and roles. Therefore, you cannot use ``--restoreDbUsersAndRoles`` 
+        on the ``admin`` database, and attempting to do so results in an error. 
 
 .. option:: --writeConcern=<document>
 

--- a/source/mongorestore.txt
+++ b/source/mongorestore.txt
@@ -729,8 +729,8 @@ Options
         was created with the :option:`--dumpDbUsersAndRoles` option. 
 
       - Restoring the ``admin`` database by specifying 
-        :option:`--db admin <mongorestore --db>` auotmatically restores all 
-        users and roles. Therefore, you cannot use ``--restoreDbUsersAndRoles`` 
+        :option:`--db admin <mongorestore --db>` automatically restores all 
+        users and roles. You cannot use ``--restoreDbUsersAndRoles`` 
         on the ``admin`` database, and attempting to do so results in an error. 
 
 .. option:: --writeConcern=<document>


### PR DESCRIPTION
## DESCRIPTION
- ``restoreDbUsersAndRoles`` requires ``dumpDbUsersAndRoles``
- This PR also cleans up wording about using``restoreDbUsersAndRoles`` on the ``admin`` database.

## STAGING
https://deploy-preview-182--docs-commandline-tools.netlify.app/mongorestore/#std-option-mongorestore.--restoreDbUsersAndRoles

## JIRA
https://jira.mongodb.org/browse/DOCSP-46246

