### PR TITLE
DOCSP-48055-mongodump-oplog-sharding-limit

### DIFF
--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -719,8 +719,7 @@ Options
    the backup.
 
    To back up individual replica sets while still accepting writes, use
-   ``--oplog``. To back up sharded clusters with ``mongodump``, see
-   :ref:`backup-sharded-dumps`.
+   ``--oplog``.
 
    .. important::
       
@@ -739,6 +738,9 @@ Options
    :term:`oplog`. This includes all members of a replica set.
    
    ``--oplog`` does not dump the oplog collection.
+
+   You can't run ``mongodump`` with ``--oplog`` on a sharded cluster. To back up 
+   sharded clusters with ``mongodump``, see :ref:`backup-sharded-dumps`.
    
    .. note::
    


### PR DESCRIPTION
## DESCRIPTION
Explicitly notes limitation that you can't run `mongodump` with `--oplog` on sharded clusters.

## STAGING
https://deploy-preview-189--docs-commandline-tools.netlify.app/mongodump/#std-option-mongodump.--oplog:~:text=You%20can%27t%20run%20mongodump%20with%20%2D%2Doplog%20on%20a%20sharded%20cluster.%20To%20back%20up%20sharded%20clusters%20with%20mongodump%2C%20see%20Back%20Up%20a%20Self%2DManaged%20Sharded%20Cluster%20with%20a%20Database%20Dump.

## JIRA
https://jira.mongodb.org/browse/DOCSP-48055


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)