### PR TITLE
DOCSP-24323: directShardOperations req for mongostat

### DIFF
--- a/source/mongostat/mongostat-behavior.txt
+++ b/source/mongostat/mongostat-behavior.txt
@@ -45,9 +45,10 @@ with the :option:`--auth <mongod.--auth>` option, specify the
    sharded cluster, the user must also have the
    :authrole:`directShardOperations` role.
 
-The built-in role :authrole:`clusterMonitor` provides this privilege as
-well as other privileges. To create a role with just the privilege to
-run ``mongostat``, see :ref:`create-role-for-mongostat`.
+The built-in role :authrole:`clusterMonitor` provides the
+:authaction:`serverStatus` privilege as well as other
+privileges. To create a role with just the privilege to run
+``mongostat``, see :ref:`create-role-for-mongostat`.
 
 
 Learn More

--- a/source/mongostat/mongostat-behavior.txt
+++ b/source/mongostat/mongostat-behavior.txt
@@ -39,6 +39,12 @@ with the :option:`--auth <mongod.--auth>` option, specify the
 <mongostat --password>` options, and the connecting user must have the
 :authaction:`serverStatus` privilege action on the cluster resources.
 
+.. important::
+
+   Starting in MongoDB 8.0, to use ``mongostat`` to connect to a
+   sharded cluster, the user must also have the
+   :authrole:`directShardOperations` role.
+
 The built-in role :authrole:`clusterMonitor` provides this privilege as
 well as other privileges. To create a role with just the privilege to
 run ``mongostat``, see :ref:`create-role-for-mongostat`.


### PR DESCRIPTION
## DESCRIPTION

Adds a note that `directShardOperations` role is required to use `mongostat` on an 8.0 sharded cluster.

## STAGING
[Note](https://deploy-preview-190--docs-commandline-tools.netlify.app/mongostat/mongostat-behavior/#required-access)


## JIRA
[DOCSP-24323](https://jira.mongodb.org/browse/DOCSP-24323)


## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)