### PR TITLE
DOCSP-49213 documents db name requirement for excludeCollection options

### DIFF
--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -771,9 +771,9 @@ Options
    Excludes the specified collection from the ``mongodump`` output.
    To exclude multiple collections, specify the ``--excludeCollection`` multiple times.
    
-   If you use ``--excludeCollection`` option without a database specified, 
-   ``mongodump`` errors. For information on specifying a database, see
-   :option:`--db <mongodump --db>`.
+   To use the ``--excludeCollection`` option, you must specify a database. You can specify
+   a database with the :option:`--db <mongodump --db>` option or directly in 
+   :option:`--uri connection string <mongodump --uri>`.
 
 .. option:: --excludeCollectionsWithPrefix=<string>
 
@@ -781,9 +781,9 @@ Options
    outputs. To specify multiple prefixes, specify the ``--excludeCollectionsWithPrefix`` multiple
    times.
 
-   If you use ``--excludeCollectionsWithPrefix`` option without a database specified, 
-   ``mongodump`` errors. For information on specifying a database, see
-   :option:`--db <mongodump --db>`.
+   To use the ``--excludeCollection`` option, you must specify a database. You can specify
+   a database with the :option:`--db <mongodump --db>` option or directly in 
+   :option:`--uri connection string <mongodump --uri>`.
 
 .. option:: --numParallelCollections=<int>, -j=<int>
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -781,7 +781,7 @@ Options
    outputs. To specify multiple prefixes, specify the ``--excludeCollectionsWithPrefix`` multiple
    times.
 
-   To use the ``--excludeCollection`` option, you must specify a database. You can specify
+   To use the ``--excludeCollectionsWithPrefix`` option, you must specify a database. You can specify
    a database with the :option:`--db <mongodump --db>` option or directly in 
    :option:`--uri connection string <mongodump --uri>`.
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -770,12 +770,20 @@ Options
 
    Excludes the specified collection from the ``mongodump`` output.
    To exclude multiple collections, specify the ``--excludeCollection`` multiple times.
+   
+   If you use ``--excludeCollection`` option without a database specified, 
+   ``mongodump`` errors. For information on specifying a database, see
+   :option:`--db <mongodump --db>`.
 
 .. option:: --excludeCollectionsWithPrefix=<string>
 
    Excludes all collections with a specified prefix from the ``mongodump``
    outputs. To specify multiple prefixes, specify the ``--excludeCollectionsWithPrefix`` multiple
    times.
+
+   If you use ``--excludeCollectionsWithPrefix`` option without a database specified, 
+   ``mongodump`` errors. For information on specifying a database, see
+   :option:`--db <mongodump --db>`.
 
 .. option:: --numParallelCollections=<int>, -j=<int>
 

--- a/source/mongodump.txt
+++ b/source/mongodump.txt
@@ -772,8 +772,8 @@ Options
    To exclude multiple collections, specify the ``--excludeCollection`` multiple times.
    
    To use the ``--excludeCollection`` option, you must specify a database. You can specify
-   a database with the :option:`--db <mongodump --db>` option or directly in 
-   :option:`--uri connection string <mongodump --uri>`.
+   a database with the :option:`--db <mongodump --db>` option or in the
+   :option:`--uri <mongodump --uri>` connection string.
 
 .. option:: --excludeCollectionsWithPrefix=<string>
 
@@ -782,8 +782,8 @@ Options
    times.
 
    To use the ``--excludeCollectionsWithPrefix`` option, you must specify a database. You can specify
-   a database with the :option:`--db <mongodump --db>` option or directly in 
-   :option:`--uri connection string <mongodump --uri>`.
+   a database with the :option:`--db <mongodump --db>` option or in the 
+   :option:`--uri <mongodump --uri>` connection string.
 
 .. option:: --numParallelCollections=<int>, -j=<int>
 


### PR DESCRIPTION
## DESCRIPTION
Updates documentation for `excludeCollection` and `excludeCollectionsWithPrefix` options to state that a database must be specified.

## STAGING

- https://deploy-preview-195--docs-commandline-tools.netlify.app/mongodump/#std-option-mongodump.--excludeCollection
- https://deploy-preview-195--docs-commandline-tools.netlify.app/mongodump/#std-option-mongodump.--excludeCollectionsWithPrefix

## JIRA

https://jira.mongodb.org/browse/DOCSP-49213

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)