### PR TITLE
DOCSP-47144-timeseries-limitations

### DIFF
--- a/source/mongoimport/mongoimport-behavior.txt
+++ b/source/mongoimport/mongoimport-behavior.txt
@@ -85,6 +85,14 @@ Batches
 ``mongoimport`` uses a maximum batch size of 100,000 to
 perform bulk insert/upsert operations.
 
+Time Series Collections
+~~~~~~~~~~~~~~~~~~~~~~~
+
+``mongoimport`` can only import data into a :ref:`time series collection <manual-timeseries-landing>` created before running
+``mongoimport``. ``mongoimport`` does not support creating time series collections
+automatically. To import time series data, run :authAction:`createCollection` on your new
+instance first, then pass in the existing time series collection to ``mongoimport``.
+
 Required Access
 ---------------
 

--- a/source/mongoimport/mongoimport-behavior.txt
+++ b/source/mongoimport/mongoimport-behavior.txt
@@ -90,7 +90,7 @@ Time Series Collections
 
 ``mongoimport`` can only import data into a :ref:`time series collection <manual-timeseries-landing>` created before running
 ``mongoimport``. ``mongoimport`` does not support creating time series collections
-automatically. To import time series data, run :authAction:`createCollection` on your new
+automatically. To import time series data, run :authaction:`createCollection` on your new
 instance first, then pass in the existing time series collection to ``mongoimport``.
 
 Required Access

--- a/source/mongoimport/mongoimport-behavior.txt
+++ b/source/mongoimport/mongoimport-behavior.txt
@@ -90,7 +90,7 @@ Time Series Collections
 
 ``mongoimport`` can only import data into a :ref:`time series collection <manual-timeseries-landing>` created before running
 ``mongoimport``. ``mongoimport`` does not support creating time series collections
-automatically. To import time series data, run :authaction:`createCollection` on your new
+automatically. To import time series data, run :method:`~db.createCollection()` on your MongoDB
 instance first, then pass in the existing time series collection to ``mongoimport``.
 
 Required Access

--- a/source/mongoimport/mongoimport-behavior.txt
+++ b/source/mongoimport/mongoimport-behavior.txt
@@ -91,7 +91,7 @@ Time Series Collections
 ``mongoimport`` can only import data into a :ref:`time series collection <manual-timeseries-landing>` created before running
 ``mongoimport``. ``mongoimport`` does not support creating time series collections
 automatically. To import time series data, run :method:`~db.createCollection()` on your MongoDB
-instance first, then pass in the existing time series collection to ``mongoimport``.
+instance first, then pass in the time series collection you created to ``mongoimport``.
 
 Required Access
 ---------------

--- a/source/mongoimport/mongoimport-behavior.txt
+++ b/source/mongoimport/mongoimport-behavior.txt
@@ -88,10 +88,9 @@ perform bulk insert/upsert operations.
 Time Series Collections
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-``mongoimport`` can only import data into a :ref:`time series collection <manual-timeseries-landing>` created before running
-``mongoimport``. ``mongoimport`` does not support creating time series collections
-automatically. To import time series data, run :method:`~db.createCollection()` on your MongoDB
-instance first, then pass in the time series collection you created to ``mongoimport``.
+To import time series data, you must create a :ref:`time series collection <manual-timeseries-landing>`
+before running ``mongoimport``. ``mongoimport`` does not support creating time series collections
+automatically. For more information about creating a collection, see :method:`~db.createCollection()`.
 
 Required Access
 ---------------


### PR DESCRIPTION
## DESCRIPTION

Add timeseries limitations to mongoimport behavior

## STAGING

https://deploy-preview-197--docs-commandline-tools.netlify.app/mongoimport/mongoimport-behavior/

## JIRA

https://jira.mongodb.org/browse/DOCSP-47144

## BUILD LOG

https://app.netlify.com/sites/docs-commandline-tools/deploys/6807fed2f4712b0008334059

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)